### PR TITLE
docs: add Blaze to list of projects

### DIFF
--- a/content/next/index.md
+++ b/content/next/index.md
@@ -159,6 +159,7 @@ The first draft of this specification has been written in collaboration with som
 * [massive.js](https://github.com/dmfay/massive-js): A data access library for Node and PostgreSQL.
 * [electron](https://github.com/electron/electron): Build cross-platform desktop apps with JavaScript, HTML, and CSS.
 * [scroll-utility](https://github.com/LeDDGroup/scroll-utility): A simple to use scroll utility package for centering elements, and smooth animations
+* [Blaze UI](https://github.com/BlazeUI/blaze): Framework-free open source modular toolkit.
 
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 


### PR DESCRIPTION
Blaze uses commitlint to ensure conventional commits are being written and it's really helped with automatically creating our change logs per package, in other words we now have some change logs!