### PR TITLE
chore(readme): update config.yml to match config.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ to send a pull request.
 
 1. Create a new file in `./content/version/index.{lang}.md` using the hugo command `hugo new {version}/index.{lang}.md`.
 1. Ensure all files have the appropriate fields required (see others as an example)..
-1. Add the language to the `config.yml` file (see others as an example).
+1. Add the language to the `config.yaml` file (see others as an example).
 
 ### Running project locally
 


### PR DESCRIPTION
The file extension used in the repository for the config file is .yaml, but the readme.md says config.yml, they are the same but might be misleading.