### PR TITLE
Add 'resolves:' type for message body

### DIFF
--- a/content/next/index.md
+++ b/content/next/index.md
@@ -69,6 +69,10 @@ fixes: #12
 resolves: #16
 ```
 
+When to use `fixes:` is clear where as `resolves:` might be a little
+confusing to here is how to use it, if additional change is hard to
+label using one of existing types `chore:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
+
 ## Specification
 
 The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).

--- a/content/next/index.md
+++ b/content/next/index.md
@@ -65,7 +65,8 @@ fix: minor typos in code
 
 see the issue for details on the typos fixed
 
-fixes issue #12
+fixes: #12
+resolves: #16
 ```
 
 ## Specification


### PR DESCRIPTION
This PR follows issue #135.

The reason behind this is to provide a meaningful way to identify additional work which was
part of commit for example if change is hard to label using one of existing types
`chore:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.

Sample commit message 

```
chore: create regular changelogs

Create changelog for a new version. 

resolves: #16
```