### PR TITLE
docs: use imperative mood in descriptions

### DIFF
--- a/content/next/index.md
+++ b/content/next/index.md
@@ -56,12 +56,12 @@ docs: correct spelling of CHANGELOG
 
 ### Commit message with scope
 ```
-feat(lang): added polish language
+feat(lang): add polish language
 ```
 
 ### Commit message for a fix using an (optional) issue number.
 ```
-fix: minor typos in code
+fix: correct minor typos in code
 
 see the issue for details on the typos fixed
 


### PR DESCRIPTION
Conventional Commits is silent on the grammatical structure of commit
descriptions, but logs are easier to read if that structure is consistent.

Convert the examples to imperative mood so they all read similarly:

  allow provided config object to extend other configs
  correct spelling of CHANGELOG
  add polish language
  correct minor typos in code

More discussion of the topic:

  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
  https://chris.beams.io/posts/git-commit/