### PR TITLE
docs: add yii2-firestarter to the project list

### DIFF
--- a/content/next/index.md
+++ b/content/next/index.md
@@ -192,6 +192,8 @@ Configurable and usable for PHP projects as a composer dependency or usable glob
 * [Monica](https://github.com/monicahq/monica): An open source personal relationship management system.
 * [mhy](https://mhy.js.org): 🧩 A zero-config, out-of-the-box, multi-purpose toolbox and development environment.
 * [@thi.ng/umbrella](https://github.com/thi-ng/umbrella): Monorepo of ~100 TypeScript projects for data driven development
+* [yii2-basic-firestarter](https://github.com/HunWalk/yii2-basic-firestarter): 🔥 An enhanced Yii2 app template.
+
 
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 


### PR DESCRIPTION
Using CC in my project :fire:. It is quite new yet, but it's getting there.
Also the latest feature encourages users to use the `fire/commit` command which helps commiting conventionally from terminal using [php-commitizen](https://github.com/damianopetrungaro/php-commitizen).