### PR TITLE
fix(zh): improve translation of scope

### DIFF
--- a/content/v1.0.0-beta.4/index.zh.md
+++ b/content/v1.0.0-beta.4/index.zh.md
@@ -10,7 +10,7 @@ aliases: ["/zh/"]
 约定式提交规范是一种基于提交消息的轻量级约定。
 它提供了一组用于创建清晰的提交历史的简单规则；
 这使得编写基于规范的自动化工具变得更容易。
-这个约定与 [SemVer](http://semver.org) 相吻合，
+这个约定与 [SemVer](http://semver.org) 相对应，
 在提交信息中描述新特性、bug 修复和破坏性变更。
 
 提交说明的结构如下所示：
@@ -18,7 +18,7 @@ aliases: ["/zh/"]
 ---
 
 ```
-<类型>[可选的作用域]: <描述>
+<类型>[可选的范围]: <描述>
 
 [可选的正文]
 
@@ -37,7 +37,7 @@ aliases: ["/zh/"]
 我们也推荐使用`improvement`，用于对当前实现进行改进而没有添加新功能或修复错误的提交。
 请注意，这些标签在约定式提交规范中并不是强制性的。并且在语义化版本中没有隐式的影响（除非他们包含 BREAKING CHANGE）。
 <br />
-可以为提交类型添加一个围在圆括号内的作用域，以为其提供额外的上下文信息。例如 `feat(parser): adds ability to parse arrays.`。
+可以为提交类型添加一个围在圆括号内的范围，以为其提供额外的上下文。例如 `feat(parser): adds ability to parse arrays.`。
 
 ## 示例
 
@@ -60,7 +60,7 @@ BREAKING CHANGE: dropping Node 6 which hits end of life in April
 docs: correct spelling of CHANGELOG
 ```
 
-### 包含作用域的提交说明
+### 包含范围的提交说明
 ```
 feat(lang): add polish language
 ```
@@ -78,18 +78,18 @@ closes issue #12
 
 本文中的关键词 “必须（MUST）”、“禁止（MUST NOT）”、“必要（REQUIRED）”、“应当（SHALL）”、“不应当（SHALL NOT）”、“应该（SHOULD）”、“不应该（SHOULD NOT）”、“推荐（RECOMMENDED）”、“可以（MAY）” 和 “可选（OPTIONAL）” ，解释参考 [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt) 中所述。
 
-1. 每个提交都**必须**使用类型字段前缀，它由一个名词组成，诸如 `feat` 或 `fix` ，其后接一个**可选的**作用域字段，以及一个**必要的**冒号（英文半角）和空格。
+1. 每个提交都**必须**使用类型字段前缀，它由一个名词组成，诸如 `feat` 或 `fix` ，其后接一个**可选的**范围字段，以及一个**必要的**冒号（英文半角）和空格。
 1. 当一个提交为应用或类库实现了新特性时，**必须**使用 `feat` 类型。
 1. 当一个提交为应用修复了 bug 时，**必须**使用 `fix` 类型。
-1. 作用域字段**可以**跟随在类型字段后面。作用域**必须**是一个描述某部分代码的名词，并用圆括号包围，例如： `fix(parser):`
-1. 描述字段**必须**紧接在类型/作用域前缀的空格之后。描述指的是对代码变更的简短总结，例如： _fix: array parsing issue when multiple spaces were contained in string._
+1. 范围字段**可以**跟随在类型字段后面。范围**必须**是一个描述某部分代码的名词，并用圆括号包围，例如： `fix(parser):`
+1. 描述字段**必须**紧接在类型/范围前缀的空格之后。描述指的是对代码变更的简短总结，例如： _fix: array parsing issue when multiple spaces were contained in string._
 1. 在简短描述之后，**可以**编写更长的提交正文，为代码变更提供额外的上下文信息。正文**必须**起始于描述字段结束的一个空行后。
 1. 在正文结束的一个空行之后，**可以**编写一行或多行脚注。脚注**必须**包含关于提交的元信息，例如：关联的合并请求、Reviewer、破坏性变更，每条元信息一行。
 1. 破坏性变更**必须**标示在正文区域最开始处，或脚注区域中某一行的开始。一个破坏性变更**必须**包含大写的文本 `BREAKING CHANGE`，后面紧跟冒号和空格。
 1. 在 `BREAKING CHANGE: ` 之后**必须**提供描述，以描述对 API 的变更。例如： _BREAKING CHANGE: environment variables now take precedence over config files._
 1. 在提交说明中，**可以**使用 `feat` 和 `fix` 之外的类型。
 1. 工具的实现**必须不**区分大小写地解析构成约定式提交的信息单元，只有 `BREAKING CHANGE` **必须**是大写的。
-1. **可以**在类型/作用域前缀之后，`:` 之前，附加 `!` 字符，以进一步提醒注意破坏性变更。当有 `!` 前缀时，正文或脚注内**必须**包含 `BREAKING CHANGE: description`
+1. **可以**在类型/范围前缀之后，`:` 之前，附加 `!` 字符，以进一步提醒注意破坏性变更。当有 `!` 前缀时，正文或脚注内**必须**包含 `BREAKING CHANGE: description`
 
 ## 为什么使用约定式提交
 
@@ -127,7 +127,7 @@ closes issue #12
 
 ### 我对约定式提交做了形如 `@jameswomack/conventional-commit-spec` 的扩展，该如何版本化管理这些扩展呢？
 
-我们推荐使用 SemVer 来发布你对于这个规范的扩展（并鼓励你创建这些扩展！）
+我们推荐使用 SemVer 来发布你对于这个规范的扩展。（我们鼓励你创建这些扩展！）
 
 ### 如果我不小心使用了错误的提交类型，该怎么办呢？
 


### PR DESCRIPTION
Scope should not be translated in the programming sense.