### PR TITLE
fix(ja): Fix Japanese translation typo

### DIFF
--- a/content/v1.0.0-beta.4/index.ja.md
+++ b/content/v1.0.0-beta.4/index.ja.md
@@ -88,7 +88,7 @@ docs: correct spelling of CHANGELOG
 feat(lang): add polish language
 ```
 
-### (オプション) issuenの番号を修正用のコミットメッセージに含めます
+### (オプション) issueの番号を修正用のコミットメッセージに含めます
 
 ```
 fix: correct minor typos in code


### PR DESCRIPTION
`issuen` is typo and I fix it.