### PR TITLE
fix: should use language name instead of region name

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -79,7 +79,7 @@ languages:
       - v1.0.0-beta
   zh-cn:
     weight: 2
-    languageName: "中国中文"
+    languageName: "简体中文"
     title: 约定式提交
     description: 一种用以给提交信息增加人机可读的信息的规范
     actions:
@@ -96,7 +96,7 @@ languages:
       - v1.0.0-beta
   zh-tw:
     weight: 2
-    languageName: "臺灣中文"
+    languageName: "繁體中文"
     title: 約定式提交
     description: 一種用於增加提交說明之人機可讀性意義的規範
     actions:


### PR DESCRIPTION
Should use language name instead of country/region name.
If there are translations more than traditional Chinese(繁體中文) and simplified Chinese(简体中文), It's better to follow Wikipedia's naming convention like:
大陆简体
香港繁體
澳門繁體
大马简体
新加坡简体
臺灣正體