### PR TITLE
feat!: specify commit type semver bump effects

### DIFF
--- a/content/v1.0.0-beta.4/index.md
+++ b/content/v1.0.0-beta.4/index.md
@@ -67,6 +67,13 @@ docs: correct spelling of CHANGELOG
 feat(lang): add polish language
 ```
 
+### Commit message indicating the initial stable release
+```
+docs: polish for initial release
+
+INITIAL STABLE RELEASE
+```
+
 ### Commit message for a fix using an (optional) issue number.
 ```
 fix: correct minor typos in code

--- a/content/v1.0.0-beta.4/index.md
+++ b/content/v1.0.0-beta.4/index.md
@@ -101,7 +101,10 @@ or footer, along with the `!` in the prefix.
 1. The effect of commits types on a release version bump SHOULD be as follows:
     1. If there are any breaking changes _and_ the library is _not_ in its "initial devlopment" status [as defined by semver](https://semver.org/#spec-item-4) _then_ bump the major version.
     1. Otherwise if there are any `feat` type commits bump the minor version.
-    2. Otherwise if there are any `fix` type commits bump the patch version.
+    1. Otherwise if there are any `fix` type commits bump the patch version.
+    1. Otherwise if there are other types of commits, other than `chore`, bump the patch version.
+    1. Otherwise there should be no bump.
+
 
 ## Why Use Conventional Commits
 

--- a/content/v1.0.0-beta.4/index.md
+++ b/content/v1.0.0-beta.4/index.md
@@ -100,7 +100,7 @@ per-line.
 or footer, along with the `!` in the prefix.
 1. The effect of commits types on a release version bump SHOULD be as follows:
     1. If there are any breaking changes _and_ the library is _not_ in its "initial devlopment" status [as defined by semver](https://semver.org/#spec-item-4) _then_ bump the major version.
-    1. If there is an `INITIAL STABLE RELEASE` indication _and_ the library is in its "initial development" status [as defined by semver](https://semver.org/#spec-item-4) _then_ bump the major version.
+    1. If there is an `INITIAL STABLE RELEASE` indication at the very beginning of the body section, or at the beginning of a line in the footer section _and_ the library is in its "initial development" status [as defined by semver](https://semver.org/#spec-item-4) _then_ bump the major version.
     1. Otherwise if there are any `feat` type commits then bump the minor version.
     1. Otherwise if there are any `fix` type commits then bump the patch version.
     1. Otherwise if there are other types of commits, other than `chore`, then bump the patch version.

--- a/content/v1.0.0-beta.4/index.md
+++ b/content/v1.0.0-beta.4/index.md
@@ -100,9 +100,10 @@ per-line.
 or footer, along with the `!` in the prefix.
 1. The effect of commits types on a release version bump SHOULD be as follows:
     1. If there are any breaking changes _and_ the library is _not_ in its "initial devlopment" status [as defined by semver](https://semver.org/#spec-item-4) _then_ bump the major version.
-    1. Otherwise if there are any `feat` type commits bump the minor version.
-    1. Otherwise if there are any `fix` type commits bump the patch version.
-    1. Otherwise if there are other types of commits, other than `chore`, bump the patch version.
+    1. If there is an `INITIAL STABLE RELEASE` indication _and_ the library is in its "initial development" status [as defined by semver](https://semver.org/#spec-item-4) _then_ bump the major version.
+    1. Otherwise if there are any `feat` type commits then bump the minor version.
+    1. Otherwise if there are any `fix` type commits then bump the patch version.
+    1. Otherwise if there are other types of commits, other than `chore`, then bump the patch version.
     1. Otherwise there should be no bump.
 
 

--- a/content/v1.0.0-beta.4/index.md
+++ b/content/v1.0.0-beta.4/index.md
@@ -98,6 +98,10 @@ per-line.
 1. The units of information that make up conventional commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.
 1. A `!` MAY be appended prior to the `:` in the type/scope prefix, to further draw attention to breaking changes. `BREAKING CHANGE: description` MUST also be included in the body
 or footer, along with the `!` in the prefix.
+1. The effect of commits types on a release version bump SHOULD be as follows:
+    1. If there are any breaking changes _and_ the library is _not_ in its "initial devlopment" status [as defined by semver](https://semver.org/#spec-item-4) _then_ bump the major version.
+    1. Otherwise if there are any `feat` type commits bump the minor version.
+    2. Otherwise if there are any `fix` type commits bump the patch version.
 
 ## Why Use Conventional Commits
 


### PR DESCRIPTION
Will close #165

This is a backwards compatible change because the the `SHOULD` qualifer is used rather than `MUST`. However, I am not sure the weaker form is desirable here.

ISR = `INITIAL STABLE RELEASE` the proposed indicator for transition from initial development phase to post initial development phase.

- [ ] probably should spec how ISR and `!` can play together nicely
- [ ] resolve if we should qualify with `SHOULD` or `MUST`
- [x] update examples
- [ ] update summary
- [ ] update to reflect 1.0 spec as per [comment below](https://github.com/conventional-commits/conventionalcommits.org/pull/214#issuecomment-552178546)