### PR TITLE
docs(tooling): add Conventional Commit for IntelliJ-based IDEs

### DIFF
--- a/content/v1.0.0/index.md
+++ b/content/v1.0.0/index.md
@@ -206,6 +206,7 @@ The first draft of this specification has been written in collaboration with som
 Configurable and usable for PHP projects as a composer dependency or usable globally for non-PHP projects.
 * [conform](https://github.com/autonomy/conform): a tool that can be used to enforce policies on git repositories, including Conventional Commits.
 * [standard-version](https://github.com/conventional-changelog/standard-version): Automatic versioning and CHANGELOG management, using GitHub's new squash button and the recommended Conventional Commits workflow.
+* [Conventional Commit](https://github.com/lppedd/idea-conventional-commit): provides extensible context and template-based completion for Conventional Commits, inside the VCS Commit dialog, for all [JetBrains IDEs](https://www.jetbrains.com/).
 * [Git Commit Template](https://plugins.jetbrains.com/plugin/9861-git-commit-template): Add Conventional Commits support to [JetBrains Editors](https://www.jetbrains.com/) (IntelliJ IDEA, PyCharm, PhpStorm...).
 * [commitsar](https://github.com/commitsar-app/commitsar): Go tool for checking if commits on branch are Conventional Commits compliant. Comes with Docker image for CI uses.
 * [semantic-release](https://github.com/semantic-release/semantic-release): A tool that automates the whole package release workflow including: determining the next version number, generating the release notes and publishing the package.


### PR DESCRIPTION
GitHub: https://github.com/lppedd/idea-conventional-commit
JetBrains Plugins Repository: https://plugins.jetbrains.com/plugin/13389-conventional-commit