### PR TITLE
docs: add pyhist to tooling list

### DIFF
--- a/content/next/index.md
+++ b/content/next/index.md
@@ -209,6 +209,7 @@ Configurable and usable for PHP projects as a composer dependency or usable glob
 * [commitsar](https://github.com/commitsar-app/commitsar): Go tool for checking if commits on branch are conventional commit compliant. Comes with Docker image for CI uses.
 * [semantic-release](https://github.com/semantic-release/semantic-release): A tool that automates the whole package release workflow including: determining the next version number, generating the release notes and publishing the package.
 * [ngx-semantic-version](https://github.com/d-koppenhagen/ngx-semantic-version): Automate your Angular app commit- and release-workflow by integrating _commitizen_, _commitlint_, _husky_ and _standard-version_ in your project and configuring it for using _Conventional Commits_.
+* [Pyhist](https://github.com/jgoodman8/pyhist): A Python utility to automagically update the package version from the git history and generate the Changelog.
 
 ## Projects Using Conventional Commits
 

--- a/content/v1.0.0/index.md
+++ b/content/v1.0.0/index.md
@@ -211,6 +211,7 @@ Configurable and usable for PHP projects as a composer dependency or usable glob
 * [commitsar](https://github.com/commitsar-app/commitsar): Go tool for checking if commits on branch are Conventional Commits compliant. Comes with Docker image for CI uses.
 * [semantic-release](https://github.com/semantic-release/semantic-release): A tool that automates the whole package release workflow including: determining the next version number, generating the release notes and publishing the package.
 * [VSCode Conventional Commits](https://marketplace.visualstudio.com/items?itemName=vivaxy.vscode-conventional-commits): Add Conventional Commits supports for VSCode.
+* [Pyhist](https://github.com/jgoodman8/pyhist): A Python utility to automagically update the package version from the git history and generate the Changelog.
 
 ## Projects Using Conventional Commits
 


### PR DESCRIPTION
I recently released the first stable version of [Pyhist](https://github.com/jgoodman8/pyhist), a Python utility to automatically update the package version from the git history and generate the Changelog. This tool is inspired by the Standard-Version project.
Since there isn't any similar tool for Python, I think it will be very beneficial for the Python ecosystem the support and development of this utility. So, I would like to include it in the list, to spread the news in the dev's community.