### PR TITLE
fix(deps) add missing dependencies in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:alpine
 WORKDIR /src/
 COPY ./themes/conventional-commits /src/
+RUN apk add python make g++
 RUN npm rebuild node-sass
 RUN npm install
 RUN npm run build


### PR DESCRIPTION
This PR fixes building docker image by adding missing dependencies to nginx:alpine. I have tested this on my local machine and it built and served website successfully.

I am not sure if this is related to #291 or not, since there is no clue about broken things in that issue.