### PR TITLE
docs: adding Conventional Commits Next Version

### DIFF
--- a/content/next/index.md
+++ b/content/next/index.md
@@ -212,6 +212,7 @@ Configurable and usable for PHP projects as a composer dependency or usable glob
 * [Pyhist](https://github.com/jgoodman8/pyhist): A Python utility to automagically update the package version from the git history and generate the Changelog.
 * [commitizen-tools/commitizen](https://github.com/commitizen-tools/commitizen): A Python tool built to create committing rules for projects (default: conventional commit), bump project versions, and generate changelog. Configurable and usable for both Python and non-Python project. It's highly extensible through Python.
 * [git-mkver](https://github.com/idc101/git-mkver): A tool to automatically apply semantic versioning to git repositories based on _Conventional Commits_.
+* [Conventional Commits Next Version](https://gitlab.com/DeveloperC/conventional_commits_next_version): A tooling/language agnostic utility to calculate the next Semantic Versioning based upon the _Conventional Commits_ Git commit messages since the last version.
 
 ## Projects Using Conventional Commits
 

--- a/content/v1.0.0/index.md
+++ b/content/v1.0.0/index.md
@@ -222,6 +222,7 @@ Configurable and usable for PHP projects as a composer dependency or usable glob
 * [VSCode Conventional Commits](https://marketplace.visualstudio.com/items?itemName=vivaxy.vscode-conventional-commits): Add Conventional Commits supports for VSCode.
 * [Pyhist](https://github.com/jgoodman8/pyhist): A Python utility to automagically update the package version from the git history and generate the Changelog.
 * [git-mkver](https://github.com/idc101/git-mkver): A tool to automatically apply semantic versioning to git repositories based on _Conventional Commits_.
+* [Conventional Commits Next Version](https://gitlab.com/DeveloperC/conventional_commits_next_version): A tooling/language agnostic utility to calculate the next Semantic Versioning based upon the _Conventional Commits_ Git commit messages since the last version.
 
 ## Projects Using Conventional Commits
 


### PR DESCRIPTION
Adding the tool Conventional Commits Next Version to the tooling section.