### PR TITLE
fix(tooling): Fix go-conventional-commit link

### DIFF
--- a/content/next/index.md
+++ b/content/next/index.md
@@ -200,7 +200,7 @@ The first draft of this specification has been written in collaboration with som
 
 ## Tooling for Conventional Commits
 
-* [go-conventional-commit](https://gitlab.com/digitalxero/go-conventional-commit14): go library for parsing comit messages following the specification.
+* [go-conventional-commit](https://gitlab.com/digitalxero/go-conventional-commit): go library for parsing commit messages following the specification.
 * [chglog](https://github.com/goreleaser/chglog): a tool for parsing Conventional Commits messages from git histories and turning them into templateable change logs.
 * [fastlane-plugin](https://github.com/xotahal/fastlane-plugin-semantic_release): follows the specification to manage versions and generate a changelog automatically.
 * [php-commitizen](https://github.com/damianopetrungaro/php-commitizen): a tool built to create commit messages following the Conventional Commit specs.


### PR DESCRIPTION
Fix the link, and a small typo about the description