### PR TITLE
fix: replace "refactor!" with "feat!"

### DIFF
--- a/content/next/index.md
+++ b/content/next/index.md
@@ -53,14 +53,14 @@ BREAKING CHANGE: `extends` key in config file is now used for extending other co
 
 ### Commit message with `!` to draw attention to breaking change
 ```
-refactor!: drop support for Node 6
+feat!: drop support for Node 6
 ```
 
 ### Commit message with both `!` and BREAKING CHANGE footer
 ```
-refactor!: drop support for Node 6
+feat!: drop support for Node 6
 
-BREAKING CHANGE: refactor to use JavaScript features not available in Node 6.
+BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```
 
 ### Commit message with no body


### PR DESCRIPTION
Refactoring by definition "is the process of changing a software system in such a way that it does not alter the external behavior of the code..." So, a refactoring cannot introduce a breaking change, otherwise it is not a refactoring anymore. Using `refactor` commit type and the breaking change marker `!` is a contradiction.