### PR TITLE
docs: adding changeloguru projects to next and v1.0.0 content

### DIFF
--- a/content/next/index.md
+++ b/content/next/index.md
@@ -245,6 +245,7 @@ Configurable and usable for PHP projects as a composer dependency or usable glob
 * [Jenkins X](https://jenkins-x.io/): Jenkins X provides pipeline automation, built-in GitOps, and preview environments to help teams collaborate and accelerate their software delivery at any scale.
 * [Cocogitto](https://github.com/oknozor/cocogitto): Cocogitto is a set of cli tools for the conventional commits and semver specifications.
 * [rsql-querydsl](https://github.com/ymind/rsql-querydsl): Integration RSQL query language and Querydsl framework.
+* [Changeloguru](https://github.com/haunt98/changeloguru): Auto-generate changelog from conventional commits, written in Go.
 
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 

--- a/content/v1.0.0/index.md
+++ b/content/v1.0.0/index.md
@@ -251,6 +251,7 @@ Configurable and usable for PHP projects as a composer dependency or usable glob
 * [Belajarpython](https://github.com/belajarpythoncom/belajarpython.com) Open source Indonesian python programming tutorial site.
 * [Uno Platform](https://platform.uno): Build Mobile, Desktop and WebAssembly apps with C# and XAML. Today. Open source and professionally supported.
 * [Jenkins X](https://jenkins-x.io/): Jenkins X provides pipeline automation, built-in GitOps, and preview environments to help teams collaborate and accelerate their software delivery at any scale.
+* [Changeloguru](https://github.com/haunt98/changeloguru): Auto-generate changelog from conventional commits, written in Go.
 
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 


### PR DESCRIPTION
I am author of [Changeloguru](https://github.com/haunt98/changeloguru). It is a tool to auto generate changelog (`CHANGELOG.md`) from conventional commits.

Example [CHANGELOG](https://github.com/haunt98/changeloguru/blob/main/CHANGELOG.md)