### PR TITLE
docs: add go-conventionalcommits to the tools list

### DIFF
--- a/content/next/index.md
+++ b/content/next/index.md
@@ -200,6 +200,7 @@ The first draft of this specification has been written in collaboration with som
 
 ## Tooling for Conventional Commits
 
+* [go-conventionalcommits](https://github.com/leodido/go-conventionalcommits): Full Go powers to parse conventional commits
 * [go-conventional-commit](https://gitlab.com/digitalxero/go-conventional-commit): go library for parsing commit messages following the specification.
 * [chglog](https://github.com/goreleaser/chglog): a tool for parsing Conventional Commits messages from git histories and turning them into templateable change logs.
 * [fastlane-plugin](https://github.com/xotahal/fastlane-plugin-semantic_release): follows the specification to manage versions and generate a changelog automatically.

--- a/content/v1.0.0/index.md
+++ b/content/v1.0.0/index.md
@@ -202,6 +202,7 @@ The first draft of this specification has been written in collaboration with som
 
 ## Tooling for Conventional Commits
 
+* [go-conventionalcommits](https://github.com/leodido/go-conventionalcommits): Full Go powers to parse conventional commits
 * [go-conventional-commit](https://gitlab.com/digitalxero/go-conventional-commit14): go library for parsing commit messages following the specification.
 * [chglog](https://github.com/goreleaser/chglog): a tool for parsing Conventional Commits messages from git histories and turning them into templateable change logs.
 * [fastlane-plugin](https://github.com/xotahal/fastlane-plugin-semantic_release): follows the specification to manage versions and generate a changelog automatically


### PR DESCRIPTION
The https://github.com/leodido/go-conventionalcommits contains a very fast (see [benchmarks](https://github.com/leodido/go-conventionalcommits#performances)) Go library to parse Conventional Commits.

It uses finite-state machines to implement the parsing.

Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>