### PR TITLE
Update index.md

### DIFF
--- a/content/v1.0.0/index.md
+++ b/content/v1.0.0/index.md
@@ -41,7 +41,7 @@ A BREAKING CHANGE can be part of commits of any _type_.
 
 Additional types are not mandated by the Conventional Commits specification, and have no implicit effect in Semantic Versioning (unless they include a BREAKING CHANGE).
 <br /><br />
-A scope may be provided to a commit's type, to provide additional contextual information and is contained within parenthesis, e.g., `feat(parser): add ability to parse arrays`.
+A scope may be provided to a commit's type, to provide additional contextual information and is contained within parenthesis (e.g., `feat(parser): add ability to parse arrays`).
 
 ## Examples
 
@@ -90,48 +90,48 @@ Refs #133
 
 The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
-1. Commits MUST be prefixed with a type, which consists of a noun, `feat`, `fix`, etc., followed
-  by the OPTIONAL scope, OPTIONAL `!`, and REQUIRED terminal colon and space.
+1. Commits MUST be prefixed with a type, which consists of a noun (e.g., `feat`, `fix`, etc.) followed
+  by the OPTIONAL scope (e.g., OPTIONAL `!`), and REQUIRED terminal colon and space.
 1. The type `feat` MUST be used when a commit adds a new feature to your application or library.
 1. The type `fix` MUST be used when a commit represents a bug fix for your application.
 1. A scope MAY be provided after a type. A scope MUST consist of a noun describing a
-  section of the codebase surrounded by parenthesis, e.g., `fix(parser):`
+  section of the codebase surrounded by parenthesis (e.g., `fix(parser):`).
 1. A description MUST immediately follow the colon and space after the type/scope prefix.
-The description is a short summary of the code changes, e.g., _fix: array parsing issue when multiple spaces were contained in string_.
+The description is a short summary of the code changes (e.g., `fix: array parsing issue when multiple spaces were contained in string`).
 1. A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.
 1. A commit body is free-form and MAY consist of any number of newline separated paragraphs.
 1. One or more footers MAY be provided one blank line after the body. Each footer MUST consist of
- a word token, followed by either a `:<space>` or `<space>#` separator, followed by a string value (this is inspired by the
-  [git trailer convention](https://git-scm.com/docs/git-interpret-trailers)).
-1. A footer's token MUST use `-` in place of whitespace characters, e.g., `Acked-by` (this helps differentiate
-  the footer section from a multi-paragraph body). An exception is made for `BREAKING CHANGE`, which MAY also be used as a token.
+ a word token, followed by either a `:<space>` or `<space>#` separator, followed by a string value. (This is inspired by the
+  [git trailer convention](https://git-scm.com/docs/git-interpret-trailers).)
+1. A footer's token MUST use `-` in place of whitespace characters (e.g., `Acked-by`). This helps differentiate
+  the footer section from a multi-paragraph body. An exception is made for `BREAKING CHANGE`, which MAY also be used as a token.
 1. A footer's value MAY contain spaces and newlines, and parsing MUST terminate when the next valid footer
   token/separator pair is observed.
 1. Breaking changes MUST be indicated in the type/scope prefix of a commit, or as an entry in the
   footer.
-1. If included as a footer, a breaking change MUST consist of the uppercase text BREAKING CHANGE, followed by a colon, space, and description, e.g.,
-_BREAKING CHANGE: environment variables now take precedence over config files_.
+1. If included as a footer, a breaking change MUST consist of the uppercase text BREAKING CHANGE, followed by a colon, space, and description (e.g.,
+`BREAKING CHANGE: environment variables now take precedence over config files`).
 1. If included in the type/scope prefix, breaking changes MUST be indicated by a
   `!` immediately before the `:`. If `!` is used, `BREAKING CHANGE:` MAY be omitted from the footer section,
   and the commit description SHALL be used to describe the breaking change.
-1. Types other than `feat` and `fix` MAY be used in your commit messages, e.g., _docs: updated ref docs._
+1. Types other than `feat` and `fix` MAY be used in your commit messages (e.g., `docs: updated ref docs`).
 1. The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.
 1. BREAKING-CHANGE MUST be synonymous with BREAKING CHANGE, when used as a token in a footer.
 
 ## Why Use Conventional Commits
 
-* Automatically generating CHANGELOGs.
-* Automatically determining a semantic version bump (based on the types of commits landed).
-* Communicating the nature of changes to teammates, the public, and other stakeholders.
-* Triggering build and publish processes.
-* Making it easier for people to contribute to your projects, by allowing them to explore
-  a more structured commit history.
+* Automatically generate CHANGELOGs.
+* Automatically determine semantic version bumps (based on the types of commits landed).
+* Communicate the nature of changes to teammates, the public, and other stakeholders.
+* Trigger build and publish processes.
+* Make it easier for people to contribute to your projects (by allowing easy exploration
+  of a more structured commit history).
 
 ## FAQ
 
 ### How should I deal with commit messages in the initial development phase?
 
-We recommend that you proceed as if you've already released the product. Typically *somebody*, even if it's your fellow software developers, is using your software. They'll want to know what's fixed, what breaks etc.
+We recommend that you proceed as if you've already released the product. Typically *somebody*, even if it's your fellow software developers, is using your software. They'll want to know what's fixed, what breaks, etc.
 
 ### Are the types in the commit title uppercase or lowercase?
 
@@ -153,29 +153,29 @@ Conventional Commits encourages us to make more of certain types of commits such
 
 `fix` type commits should be translated to `PATCH` releases. `feat` type commits should be translated to `MINOR` releases. Commits with `BREAKING CHANGE` in the commits, regardless of type, should be translated to `MAJOR` releases.
 
-### How should I version my extensions to the Conventional Commits Specification, e.g. `@jameswomack/conventional-commit-spec`?
+### How should I version my extensions to the Conventional Commits Specification (e.g., `@jameswomack/conventional-commit-spec`)?
 
 We recommend using SemVer to release your own extensions to this specification (and
-encourage you to make these extensions!)
+encourage you to make these extensions!).
 
 ### What do I do if I accidentally use the wrong commit type?
 
-#### When you used a type that's of the spec but not the correct type, e.g. `fix` instead of `feat`
+#### When you used a type that's of the spec but not the correct type (e.g., `fix` instead of `feat`)
 
 Prior to merging or releasing the mistake, we recommend using `git rebase -i` to edit the commit history. After release, the cleanup will be different according to what tools and processes you use.
 
-#### When you used a type *not* of the spec, e.g. `feet` instead of `feat`
+#### When you used a type *not* of the spec (e.g., `feet` instead of `feat`)
 
 In a worst case scenario, it's not the end of the world if a commit lands that does not meet the Conventional Commits specification. It simply means that commit will be missed by tools that are based on the spec.
 
 ### Do all my contributors need to use the Conventional Commits specification?
 
-No! If you use a squash based workflow on Git lead maintainers can clean up the commit messages as they're merged—adding no workload to casual committers.
-A common workflow for this is to have your git system automatically squash commits from a pull request and present a form for the lead maintainer to enter the proper git commit message for the merge.
+No! If you use a squash-based workflow in Git, lead maintainers can clean up the commit messages as they're merged—adding no workload to casual committers.
+A common workflow for this is to have your git setup automatically squash commits from a pull request and present a form for the lead maintainer to enter the proper git commit message for the merge.
 
 ### How does Conventional Commits handle revert commits?
 
-Reverting code can be complicated: are you reverting multiple commits? if you revert a feature, should the next release instead be a patch?
+Reverting code can be complicated. (Are you reverting multiple commits? If you revert a feature, should the next release instead be a patch?)
 
 Conventional Commits does not make an explicit effort to define revert behavior. Instead we leave it to tooling
 authors to use the flexility of _types_ and _footers_ to develop their logic for handling reverts.
@@ -194,67 +194,67 @@ The Conventional Commits specification is inspired by, and based heavily on, the
 
 The first draft of this specification has been written in collaboration with some of the folks contributing to:
 
-* [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog): a set of tools for parsing Conventional Commits messages from git histories.
-* [parse-commit-message](https://npmjs.com/package/parse-commit-message): Extensible utilities for parsing, stringify and validating Conventional Commit messages.
-* [bumped](https://bumped.github.io): a tool for releasing software that makes it easy to perform actions before and after releasing a new version of your software.
-* [unleash](https://github.com/netflix/unleash): a tool for automating the software release and publishing lifecycle.
-* [lerna](https://github.com/lerna/lerna): a tool for managing monorepos, which grew out of the Babel project.
+* [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog): A set of tools for parsing Conventional Commits messages from git histories.
+* [parse-commit-message](https://npmjs.com/package/parse-commit-message): Extensible utilities for parsing, stringifying, and validating Conventional Commit messages.
+* [bumped](https://bumped.github.io): A tool for releasing software that makes it easy to perform actions before and after releasing a new version of your software.
+* [unleash](https://github.com/netflix/unleash): A tool for automating the software release and publishing lifecycle.
+* [lerna](https://github.com/lerna/lerna): A tool for managing monorepos (which grew out of the Babel project).
 
 ## Tooling for Conventional Commits
 
-* [go-conventional-commit](https://gitlab.com/digitalxero/go-conventional-commit14): go library for parsing commit messages following the specification.
-* [chglog](https://github.com/goreleaser/chglog): a tool for parsing Conventional Commits messages from git histories and turning them into templateable change logs.
-* [fastlane-plugin](https://github.com/xotahal/fastlane-plugin-semantic_release): follows the specification to manage versions and generate a changelog automatically
+* [go-conventional-commit](https://gitlab.com/digitalxero/go-conventional-commit14): Go library for parsing commit messages according to the specification.
+* [chglog](https://github.com/goreleaser/chglog): A tool for parsing Conventional Commits messages from git histories and turning them into templateable change logs.
+* [fastlane-plugin](https://github.com/xotahal/fastlane-plugin-semantic_release): Follows the specification to manage versions and generate a changelog automatically.
 * [commitizen/cz-cli](https://github.com/commitizen/cz-cli): A Node.js tool to create commit messages following the Conventional Commits specs.
-* [commitizen-tools/commitizen](https://github.com/commitizen-tools/commitizen): A tool written in Python to create commiting rules for projects, auto bump versions and auto changelog generation.
+* [commitizen-tools/commitizen](https://github.com/commitizen-tools/commitizen): A tool written in Python to create commiting rules for projects, auto-bump versions, and auto-generate changelogs.
 * [php-commitizen](https://github.com/damianopetrungaro/php-commitizen): A PHP tool built to create commit messages following the Conventional Commits specs.
 Configurable and usable for PHP projects as a composer dependency or usable globally for non-PHP projects.
-* [php-conventional-changelog](https://github.com/marcocesarato/php-conventional-changelog): a tool built to generate a changelog from a project's committing history messages and metadata and automate versioning with Semver, following Conventional Commits specs. Configurable and usable for PHP projects as a composer dependency or usable globally for non-PHP projects.
+* [php-conventional-changelog](https://github.com/marcocesarato/php-conventional-changelog): A tool built to generate a changelog from a project's commit history and metadata, and automate versioning with Semver according to Conventional Commits specs. Configurable and usable for PHP projects as a composer dependency or usable globally for non-PHP projects.
 * [commitlint](https://github.com/conventional-changelog/commitlint): A linter to check that your commit messages meet the Conventional Commits format.
 * [gitlint](https://github.com/jorisroovers/gitlint): Git commit message linter written in Python, which can be configured to [enforce Conventional Commits format](https://jorisroovers.com/gitlint/contrib_rules/#ct1-contrib-title-conventional-commits).
-* [conform](https://github.com/autonomy/conform): a tool that can be used to enforce policies on git repositories, including Conventional Commits.
-* [detect-next-version](https://npmjs.com/package/detect-next-version): Parse, detect and get more metadata about given Conventional Commits.
-* [recommended-bump](https://www.npmjs.com/package/recommended-bump): Calculcates the recommended version bump based on given Conventional Commits.
-* [git-commits-since](https://www.npmjs.com/package/git-commits-since): Get all (raw) commits since period or (by default) from latest git SemVer tag, plus plugins support.
+* [conform](https://github.com/autonomy/conform): A tool that can be used to enforce policies on git repositories, including Conventional Commits.
+* [detect-next-version](https://npmjs.com/package/detect-next-version): Parse, detect, and get more metadata about given Conventional Commits.
+* [recommended-bump](https://www.npmjs.com/package/recommended-bump): Calculcate the recommended version bump based on given Conventional Commits.
+* [git-commits-since](https://www.npmjs.com/package/git-commits-since): Get all (raw) commits since period, or (by default) from latest git SemVer tag, plus plugins support.
 * [standard-version](https://github.com/conventional-changelog/standard-version): Automatic versioning and CHANGELOG management, using GitHub's new squash button and the recommended Conventional Commits workflow.
-* [Conventional Commit](https://github.com/lppedd/idea-conventional-commit): provides extensible context and template-based completion, and inspections, for Conventional Commits inside the VCS Commit dialog. Available for all [JetBrains IDEs](https://www.jetbrains.com/).
-* [Git Commit Template](https://plugins.jetbrains.com/plugin/9861-git-commit-template): Add Conventional Commits support to [JetBrains Editors](https://www.jetbrains.com/) (IntelliJ IDEA, PyCharm, PhpStorm...).
+* [Conventional Commit](https://github.com/lppedd/idea-conventional-commit): Provides extensible context, template-based completion, and inspections for Conventional Commits inside the VCS Commit dialog. Available for all [JetBrains IDEs](https://www.jetbrains.com).
+* [Git Commit Template](https://plugins.jetbrains.com/plugin/9861-git-commit-template): Add Conventional Commits support to [JetBrains Editors](https://www.jetbrains.com) (IntelliJ IDEA, PyCharm, PhpStorm...).
 * [commitsar](https://github.com/commitsar-app/commitsar): Go tool for checking if commits on branch are Conventional Commits compliant. Comes with Docker image for CI uses.
-* [semantic-release](https://github.com/semantic-release/semantic-release): A tool that automates the whole package release workflow including: determining the next version number, generating the release notes and publishing the package.
-* [python-semantic-release](https://github.com/relekang/python-semantic-release): Automatic Semantic Versioning for Python projects. This is a Python implementation of the [semantic-release](https://github.com/semantic-release/semantic-release) for Node.js.
+* [semantic-release](https://github.com/semantic-release/semantic-release): Automates the whole package release workflow, including: determining the next version number, generating the release notes, and publishing the package.
+* [python-semantic-release](https://github.com/relekang/python-semantic-release): Automatic Semantic Versioning for Python projects. This is a Python implementation of the Node.js [semantic-release](https://github.com/semantic-release/semantic-release) package.
 * [VSCode Conventional Commits](https://marketplace.visualstudio.com/items?itemName=vivaxy.vscode-conventional-commits): Add Conventional Commits supports for VSCode.
 * [Pyhist](https://github.com/jgoodman8/pyhist): A Python utility to automagically update the package version from the git history and generate the Changelog.
 * [git-mkver](https://github.com/idc101/git-mkver): A tool to automatically apply Semantic Versioning to git repositories based on _Conventional Commits_.
-* [Conventional Commits Next Version](https://gitlab.com/DeveloperC/conventional_commits_next_version): A tooling and language agnostic utility to calculate the next semantic version based on the _Conventional Commits_ since the prior version. Supports monorepos.
+* [Conventional Commits Next Version](https://gitlab.com/DeveloperC/conventional_commits_next_version): A tooling- and language-agnostic utility to calculate the next semantic version based on the _Conventional Commits_ since the prior version. Supports monorepos.
 * [change](https://github.com/adamtabrams/change): A tool for generating and updating a changelog using Conventional Commits.
 * [Turbogit](https://b4nst.github.io/turbogit): A command line tool to help you follow _Conventional Commits_ flow.
-* [sv4git](https://github.com/bvieira/sv4git): A command line tool (CLI) to validate commit messages, bump versions, create tags and generate changelogs.
+* [sv4git](https://github.com/bvieira/sv4git): A command line interface (CLI) to validate commit messages, bump versions, create tags, and generate changelogs.
 * [Versio](https://github.com/chaaz/versio): A monorepo-compatible tool that updates version numbers based on conventional commits and project dependencies. It can generate tags and changelogs, too.
 
 ## Projects Using Conventional Commits
 
-* [NFPM](https://github.com/goreleaser/nfpm): NFPM is Not FPM - a simple deb, rpm and apk packager written in Go
-* [yargs](https://github.com/yargs/yargs): everyone's favorite pirate themed command line argument parser.
-* [istanbuljs](https://github.com/istanbuljs/istanbuljs): a collection of open-source tools and libraries for adding test coverage to your JavaScript tests.
-* [uPortal-home](https://github.com/UW-Madison-DoIT/angularjs-portal) and [uPortal-application-framework](https://github.com/UW-Madison-DoIT/uw-frame): Optional supplemental user interface enhancing [Apereo uPortal](https://www.apereo.org/projects/uportal).
+* [NFPM](https://github.com/goreleaser/nfpm): NFPM is Not FPM - A simple deb, rpm, and apk packager written in Go.
+* [yargs](https://github.com/yargs/yargs): Everyone's favorite pirate-themed command line argument parser.
+* [istanbuljs](https://github.com/istanbuljs/istanbuljs): A collection of open-source tools and libraries for adding test coverage to your JavaScript tests.
+* [uPortal-home](https://github.com/UW-Madison-DoIT/angularjs-portal) A [uPortal-application-framework](https://github.com/UW-Madison-DoIT/uw-frame): Optional supplemental user interface enhancing [Apereo uPortal](https://www.apereo.org/projects/uportal).
 * [massive.js](https://github.com/dmfay/massive-js): A data access library for Node and PostgreSQL.
 * [electron](https://github.com/electron/electron): Build cross-platform desktop apps with JavaScript, HTML, and CSS.
-* [scroll-utility](https://github.com/LeDDGroup/scroll-utility): A simple to use scroll utility package for centering elements, and smooth animations
+* [scroll-utility](https://github.com/LeDDGroup/scroll-utility): A simple to use scroll utility package for centering elements, and smooth animations.
 * [Blaze UI](https://github.com/BlazeUI/blaze): Framework-free open source UI toolkit.
 * [Monica](https://github.com/monicahq/monica): An open source personal relationship management system.
 * [mhy](https://mhy.js.org): A zero-config, out-of-the-box, multi-purpose toolbox and development environment.
 * [@tandil/diffparse](https://github.com/danielduarte/diffparse#readme): Simple parser for Diff files (unified diff format).
 * [@tandil/diffsplit](https://github.com/danielduarte/diffsplit#readme): Easy split of .diff & .patch into its files.
-* [@thi.ng/umbrella](https://github.com/thi-ng/umbrella): Monorepo of ~100 TypeScript projects for data driven development
+* [@thi.ng/umbrella](https://github.com/thi-ng/umbrella): Monorepo of ~100 TypeScript projects for data driven development.
 * [yii2-basic-firestarter](https://github.com/HunWalk/yii2-basic-firestarter): 🔥 An enhanced Yii2 app template.
 * [dcyou/resume](https://github.com/dcyou/resume): 😎 Template to easily and quickly create your online CV.
 * [Nintex Forms](https://www.nintex.com/workflow-automation/modern-forms/): Easily create dynamic online forms to capture and submit accurate and current data.
 * [Tina CMS](https://tinacms.org): An open source toolkit for building front-end content-management into your website.
-* [Belajarpython](https://github.com/belajarpythoncom/belajarpython.com) Open source Indonesian python programming tutorial site.
+* [Belajarpython](https://github.com/belajarpythoncom/belajarpython.com) Open source Indonesian Python programming tutorial site.
 * [Uno Platform](https://platform.uno): Build Mobile, Desktop and WebAssembly apps with C# and XAML. Today. Open source and professionally supported.
 * [Jenkins X](https://jenkins-x.io/): Jenkins X provides pipeline automation, built-in GitOps, and preview environments to help teams collaborate and accelerate their software delivery at any scale.
 * [Changeloguru](https://github.com/haunt98/changeloguru): Auto-generate changelog from conventional commits, written in Go.
 
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 
-_want your project on this list?_ [send a pull request](https://github.com/conventional-changelog/conventionalcommits.org/pulls).
+_Want your project on this list?_ [Send a pull request](https://github.com/conventional-changelog/conventionalcommits.org/pulls).


### PR DESCRIPTION
docs(spec): Minor copy edits to capitalization, phrasing, punctuation, and formatting.

Edit goals:

- No edits should change the meaning of the edited text
- Consistency of punctuation for repeated phrases (e.g., all “e.g.” statements in parentheses like this)
- Consistency of capital letters for each description in the lists of links at the end of the document
- Consistency of formatting inline examples (e.g., always format example commits with `backticks`, rather than mixing `backticks` and _italics_)

A few other minor copy edits are totally subjective, and (hopefully) provide some subtle aesthetic improvement.  (Or, at least, go unnoticed. That’s okay, too. :-) )