### PR TITLE
docs(tooling): add uplift to the list of existing tooling

### DIFF
--- a/content/about/index.md
+++ b/content/about/index.md
@@ -53,6 +53,7 @@ The first draft of this specification has been written in collaboration with som
     * [Jenkins](https://github.com/jenkinsci/git-changelog-plugin)
     * [Command Line](https://github.com/tomasbjerre/git-changelog-command-line)
 * [Cocogitto](https://github.com/oknozor/cocogitto): Cocogitto is a set of cli tools for the conventional commits and semver specifications.
+* [Uplift](https://github.com/gembaadvantage/uplift): Semantic versioning the easy way. Powered by Conventional Commits. Built for use with CI
 
 ## Projects Using Conventional Commits
 

--- a/content/next/index.md
+++ b/content/next/index.md
@@ -228,6 +228,7 @@ Configurable and usable for PHP projects as a composer dependency or usable glob
   * [Jenkins](https://github.com/jenkinsci/git-changelog-plugin)
   * [Command Line](https://github.com/tomasbjerre/git-changelog-command-line)
 * [Cocogitto](https://github.com/oknozor/cocogitto): Cocogitto is a set of cli tools for the conventional commits and semver specifications.
+* [Uplift](https://github.com/gembaadvantage/uplift): Semantic versioning the easy way. Powered by Conventional Commits. Built for use with CI
 
 ## Projects Using Conventional Commits
 


### PR DESCRIPTION
I have designed a new conventional commit based tool, written in Go. It utilises conventional commits to automatically bump a semantic version in any file and tag the repository for release. I would appreciate it if I could add it to the list of existing tools. Thanks. 

Keep up the good work!