### PR TITLE
docs: improve example

### DIFF
--- a/content/next/index.md
+++ b/content/next/index.md
@@ -80,14 +80,16 @@ feat(lang): add polish language
 
 ### Commit message with multi-paragraph body and multiple footers
 ```
-fix: correct minor typos in code
+refactor: simplify event distribution
 
-see the issue for details
+Standardize event distribution, reduce varying boiler code and increase
+maintainability.
 
-on typos fixed.
+As a further result implementation of #123 as a subscriber to newly
+introduced EventSource is now easily possible.
 
 Reviewed-by: Z
-Refs #133
+Refs: #123
 ```
 
 ## Specification

--- a/content/next/index.md
+++ b/content/next/index.md
@@ -80,13 +80,13 @@ feat(lang): add polish language
 
 ### Commit message with multi-paragraph body and multiple footers
 ```
-refactor: simplify event distribution
+fix: prevent racing of requests
 
-Standardize event distribution, reduce varying boiler code and increase
-maintainability.
+Introduce a request id and a reference to latest request. Dismiss
+incoming responses other than from latest request.
 
-As a further result implementation of #123 as a subscriber to newly
-introduced EventSource is now easily possible.
+Remove timeouts which were used to mitigate the racing issue but are
+obsolete now.
 
 Reviewed-by: Z
 Refs: #123

--- a/content/v1.0.0/index.de.md
+++ b/content/v1.0.0/index.de.md
@@ -79,13 +79,13 @@ feat(lang): add polish language
 
 ### Commit-Nachricht mit mehreren Absätzen und Fußzeilen
 ```
-refactor: simplify event distribution
+fix: prevent racing of requests
 
-Standardize event distribution, reduce varying boiler code and increase
-maintainability.
+Introduce a request id and a reference to latest request. Dismiss
+incoming responses other than from latest request.
 
-As a further result implementation of #123 as a subscriber to newly
-introduced EventSource is now easily possible.
+Remove timeouts which were used to mitigate the racing issue but are
+obsolete now.
 
 Reviewed-by: Z
 Refs: #123

--- a/content/v1.0.0/index.de.md
+++ b/content/v1.0.0/index.de.md
@@ -79,14 +79,16 @@ feat(lang): add polish language
 
 ### Commit-Nachricht mit mehreren Absätzen und Fußzeilen
 ```
-fix: correct minor typos in code
+refactor: simplify event distribution
 
-see the issue for details
+Standardize event distribution, reduce varying boiler code and increase
+maintainability.
 
-on typos fixed.
+As a further result implementation of #123 as a subscriber to newly
+introduced EventSource is now easily possible.
 
 Reviewed-by: Z
-Refs #133
+Refs: #123
 ```
 
 ## Spezifikation

--- a/content/v1.0.0/index.fr.md
+++ b/content/v1.0.0/index.fr.md
@@ -81,14 +81,16 @@ feat(lang): add polish language
 
 ### Message du commit avec plusieurs paragraphes et plusieurs pieds de page
 ```
-fix: correct minor typos in code
+refactor: simplify event distribution
 
-see the issue for details
+Standardize event distribution, reduce varying boiler code and increase
+maintainability.
 
-on typos fixed.
+As a further result implementation of #123 as a subscriber to newly
+introduced EventSource is now easily possible.
 
 Reviewed-by: Z
-Refs #133
+Refs: #123
 ```
 
 ## Spécification

--- a/content/v1.0.0/index.fr.md
+++ b/content/v1.0.0/index.fr.md
@@ -81,13 +81,13 @@ feat(lang): add polish language
 
 ### Message du commit avec plusieurs paragraphes et plusieurs pieds de page
 ```
-refactor: simplify event distribution
+fix: prevent racing of requests
 
-Standardize event distribution, reduce varying boiler code and increase
-maintainability.
+Introduce a request id and a reference to latest request. Dismiss
+incoming responses other than from latest request.
 
-As a further result implementation of #123 as a subscriber to newly
-introduced EventSource is now easily possible.
+Remove timeouts which were used to mitigate the racing issue but are
+obsolete now.
 
 Reviewed-by: Z
 Refs: #123

--- a/content/v1.0.0/index.id.md
+++ b/content/v1.0.0/index.id.md
@@ -79,14 +79,16 @@ feat(lang): add polish language
 
 ### Pesan komit dengan badan multi-paragraf dan multi-footer
 ```
-fix: correct minor typos in code
+refactor: simplify event distribution
 
-see the issue for details
+Standardize event distribution, reduce varying boiler code and increase
+maintainability.
 
-on typos fixed.
+As a further result implementation of #123 as a subscriber to newly
+introduced EventSource is now easily possible.
 
 Reviewed-by: Z
-Refs #133
+Refs: #123
 ```
 
 ## Spesifikasi

--- a/content/v1.0.0/index.id.md
+++ b/content/v1.0.0/index.id.md
@@ -79,13 +79,13 @@ feat(lang): add polish language
 
 ### Pesan komit dengan badan multi-paragraf dan multi-footer
 ```
-refactor: simplify event distribution
+fix: prevent racing of requests
 
-Standardize event distribution, reduce varying boiler code and increase
-maintainability.
+Introduce a request id and a reference to latest request. Dismiss
+incoming responses other than from latest request.
 
-As a further result implementation of #123 as a subscriber to newly
-introduced EventSource is now easily possible.
+Remove timeouts which were used to mitigate the racing issue but are
+obsolete now.
 
 Reviewed-by: Z
 Refs: #123

--- a/content/v1.0.0/index.ja.md
+++ b/content/v1.0.0/index.ja.md
@@ -99,13 +99,13 @@ feat(lang): add polish language
 ### 複数段落からなる本文と複数のフッターを持ったコミットメッセージ
 
 ```
-refactor: simplify event distribution
+fix: prevent racing of requests
 
-Standardize event distribution, reduce varying boiler code and increase
-maintainability.
+Introduce a request id and a reference to latest request. Dismiss
+incoming responses other than from latest request.
 
-As a further result implementation of #123 as a subscriber to newly
-introduced EventSource is now easily possible.
+Remove timeouts which were used to mitigate the racing issue but are
+obsolete now.
 
 Reviewed-by: Z
 Refs: #123

--- a/content/v1.0.0/index.ja.md
+++ b/content/v1.0.0/index.ja.md
@@ -99,14 +99,16 @@ feat(lang): add polish language
 ### 複数段落からなる本文と複数のフッターを持ったコミットメッセージ
 
 ```
-fix: correct minor typos in code
+refactor: simplify event distribution
 
-see the issue for details
+Standardize event distribution, reduce varying boiler code and increase
+maintainability.
 
-on typos fixed.
+As a further result implementation of #123 as a subscriber to newly
+introduced EventSource is now easily possible.
 
 Reviewed-by: Z
-Refs #133
+Refs: #123
 ```
 
 ## 仕様

--- a/content/v1.0.0/index.ko.md
+++ b/content/v1.0.0/index.ko.md
@@ -76,14 +76,16 @@ feat(lang): add polish language
 
 ### 다중-단락 본문과 다수의 꼬리말을 가진 커밋 메세지
 ```
-fix: correct minor typos in code
+refactor: simplify event distribution
 
-see the issue for details
+Standardize event distribution, reduce varying boiler code and increase
+maintainability.
 
-on typos fixed.
+As a further result implementation of #123 as a subscriber to newly
+introduced EventSource is now easily possible.
 
 Reviewed-by: Z
-Refs #133
+Refs: #123
 ```
 
 ## 규격

--- a/content/v1.0.0/index.ko.md
+++ b/content/v1.0.0/index.ko.md
@@ -76,13 +76,13 @@ feat(lang): add polish language
 
 ### 다중-단락 본문과 다수의 꼬리말을 가진 커밋 메세지
 ```
-refactor: simplify event distribution
+fix: prevent racing of requests
 
-Standardize event distribution, reduce varying boiler code and increase
-maintainability.
+Introduce a request id and a reference to latest request. Dismiss
+incoming responses other than from latest request.
 
-As a further result implementation of #123 as a subscriber to newly
-introduced EventSource is now easily possible.
+Remove timeouts which were used to mitigate the racing issue but are
+obsolete now.
 
 Reviewed-by: Z
 Refs: #123

--- a/content/v1.0.0/index.md
+++ b/content/v1.0.0/index.md
@@ -81,14 +81,16 @@ feat(lang): add polish language
 
 ### Commit message with multi-paragraph body and multiple footers
 ```
-fix: correct minor typos in code
+refactor: simplify event distribution
 
-see the issue for details
+Standardize event distribution, reduce varying boiler code and increase
+maintainability.
 
-on typos fixed.
+As a further result implementation of #123 as a subscriber to newly
+introduced EventSource is now easily possible.
 
 Reviewed-by: Z
-Refs #133
+Refs: #123
 ```
 
 ## Specification

--- a/content/v1.0.0/index.md
+++ b/content/v1.0.0/index.md
@@ -81,13 +81,13 @@ feat(lang): add polish language
 
 ### Commit message with multi-paragraph body and multiple footers
 ```
-refactor: simplify event distribution
+fix: prevent racing of requests
 
-Standardize event distribution, reduce varying boiler code and increase
-maintainability.
+Introduce a request id and a reference to latest request. Dismiss
+incoming responses other than from latest request.
 
-As a further result implementation of #123 as a subscriber to newly
-introduced EventSource is now easily possible.
+Remove timeouts which were used to mitigate the racing issue but are
+obsolete now.
 
 Reviewed-by: Z
 Refs: #123

--- a/content/v1.0.0/index.ru.md
+++ b/content/v1.0.0/index.ru.md
@@ -92,14 +92,16 @@ feat(lang): add polish language
 
 ### Сообщение коммита с _телом_ из нескольких абзацев и несколькими _сносками_
 ```
-fix: correct minor typos in code
+refactor: simplify event distribution
 
-see the issue for details
+Standardize event distribution, reduce varying boiler code and increase
+maintainability.
 
-on typos fixed.
+As a further result implementation of #123 as a subscriber to newly
+introduced EventSource is now easily possible.
 
 Reviewed-by: Z
-Refs #133
+Refs: #123
 ```
 
 ## Спецификация

--- a/content/v1.0.0/index.ru.md
+++ b/content/v1.0.0/index.ru.md
@@ -92,13 +92,13 @@ feat(lang): add polish language
 
 ### Сообщение коммита с _телом_ из нескольких абзацев и несколькими _сносками_
 ```
-refactor: simplify event distribution
+fix: prevent racing of requests
 
-Standardize event distribution, reduce varying boiler code and increase
-maintainability.
+Introduce a request id and a reference to latest request. Dismiss
+incoming responses other than from latest request.
 
-As a further result implementation of #123 as a subscriber to newly
-introduced EventSource is now easily possible.
+Remove timeouts which were used to mitigate the racing issue but are
+obsolete now.
 
 Reviewed-by: Z
 Refs: #123

--- a/content/v1.0.0/index.th.md
+++ b/content/v1.0.0/index.th.md
@@ -80,13 +80,13 @@ feat(lang): add polish language
 
 ### ข้อความ commit ที่มีเนื้อหาหลายย่อหน้า และมีข้อความลงท้ายหลายข้อความ
 ```
-refactor: simplify event distribution
+fix: prevent racing of requests
 
-Standardize event distribution, reduce varying boiler code and increase
-maintainability.
+Introduce a request id and a reference to latest request. Dismiss
+incoming responses other than from latest request.
 
-As a further result implementation of #123 as a subscriber to newly
-introduced EventSource is now easily possible.
+Remove timeouts which were used to mitigate the racing issue but are
+obsolete now.
 
 Reviewed-by: Z
 Refs: #123

--- a/content/v1.0.0/index.th.md
+++ b/content/v1.0.0/index.th.md
@@ -80,14 +80,16 @@ feat(lang): add polish language
 
 ### ข้อความ commit ที่มีเนื้อหาหลายย่อหน้า และมีข้อความลงท้ายหลายข้อความ
 ```
-fix: correct minor typos in code
+refactor: simplify event distribution
 
-see the issue for details
+Standardize event distribution, reduce varying boiler code and increase
+maintainability.
 
-on typos fixed.
+As a further result implementation of #123 as a subscriber to newly
+introduced EventSource is now easily possible.
 
 Reviewed-by: Z
-Refs #133
+Refs: #123
 ```
 
 ## ข้อกำหนด

--- a/content/v1.0.0/index.uk.md
+++ b/content/v1.0.0/index.uk.md
@@ -82,13 +82,13 @@ feat(lang): add polish language
 
 ### Коміт повідомлення з тілом з кількома абзацами і додатками
 ```
-refactor: simplify event distribution
+fix: prevent racing of requests
 
-Standardize event distribution, reduce varying boiler code and increase
-maintainability.
+Introduce a request id and a reference to latest request. Dismiss
+incoming responses other than from latest request.
 
-As a further result implementation of #123 as a subscriber to newly
-introduced EventSource is now easily possible.
+Remove timeouts which were used to mitigate the racing issue but are
+obsolete now.
 
 Reviewed-by: Z
 Refs: #123

--- a/content/v1.0.0/index.uk.md
+++ b/content/v1.0.0/index.uk.md
@@ -82,14 +82,16 @@ feat(lang): add polish language
 
 ### Коміт повідомлення з тілом з кількома абзацами і додатками
 ```
-fix: correct minor typos in code
+refactor: simplify event distribution
 
-see the issue for details
+Standardize event distribution, reduce varying boiler code and increase
+maintainability.
 
-on typos fixed.
+As a further result implementation of #123 as a subscriber to newly
+introduced EventSource is now easily possible.
 
 Reviewed-by: Z
-Refs #133
+Refs: #123
 ```
 
 ## Специфікація

--- a/content/v1.0.0/index.zh-hans.md
+++ b/content/v1.0.0/index.zh-hans.md
@@ -92,13 +92,13 @@ feat(lang): add polish language
 
 ### 包含多行正文和多行脚注的提交说明
 ```
-refactor: simplify event distribution
+fix: prevent racing of requests
 
-Standardize event distribution, reduce varying boiler code and increase
-maintainability.
+Introduce a request id and a reference to latest request. Dismiss
+incoming responses other than from latest request.
 
-As a further result implementation of #123 as a subscriber to newly
-introduced EventSource is now easily possible.
+Remove timeouts which were used to mitigate the racing issue but are
+obsolete now.
 
 Reviewed-by: Z
 Refs: #123

--- a/content/v1.0.0/index.zh-hans.md
+++ b/content/v1.0.0/index.zh-hans.md
@@ -92,14 +92,16 @@ feat(lang): add polish language
 
 ### 包含多行正文和多行脚注的提交说明
 ```
-fix: correct minor typos in code
+refactor: simplify event distribution
 
-see the issue for details
+Standardize event distribution, reduce varying boiler code and increase
+maintainability.
 
-on typos fixed.
+As a further result implementation of #123 as a subscriber to newly
+introduced EventSource is now easily possible.
 
 Reviewed-by: Z
-Refs #133
+Refs: #123
 ```
 
 ## 约定式提交规范

--- a/content/v1.0.0/index.zh-hant.md
+++ b/content/v1.0.0/index.zh-hant.md
@@ -86,13 +86,13 @@ feat(lang): add polish language
 
 ### 正文有多段落以及有多個頁腳的提交說明
 ```
-refactor: simplify event distribution
+fix: prevent racing of requests
 
-Standardize event distribution, reduce varying boiler code and increase
-maintainability.
+Introduce a request id and a reference to latest request. Dismiss
+incoming responses other than from latest request.
 
-As a further result implementation of #123 as a subscriber to newly
-introduced EventSource is now easily possible.
+Remove timeouts which were used to mitigate the racing issue but are
+obsolete now.
 
 Reviewed-by: Z
 Refs: #123

--- a/content/v1.0.0/index.zh-hant.md
+++ b/content/v1.0.0/index.zh-hant.md
@@ -86,14 +86,16 @@ feat(lang): add polish language
 
 ### 正文有多段落以及有多個頁腳的提交說明
 ```
-fix: correct minor typos in code
+refactor: simplify event distribution
 
-see the issue for details
+Standardize event distribution, reduce varying boiler code and increase
+maintainability.
 
-on typos fixed.
+As a further result implementation of #123 as a subscriber to newly
+introduced EventSource is now easily possible.
 
 Reviewed-by: Z
-Refs #133
+Refs: #123
 ```
 
 ## 規範


### PR DESCRIPTION
Thanks for all your input in #348. I mostly agree with you.

I think whether to start header capitalized or not is opinionated, as long as it is consistent. I find it more natural to capitalize it but e.g. [Angular conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-header) states, it must not be capitalized. So I will leave it out of this PR. Changing it in all examples would anyway be worth an own issue and pull request in my opinion.

I felt given a shortened abstract example is nicer to read than quoting [Chris Beam's exmaple](https://chris.beams.io/posts/git-commit/#why-not-how). 

As a side note regarding *"Issues trackers can change over time"*. I think they shouldn't as they contain important information from also non technical stakeholders. But that's a completely different discussion :)

Thanks again for all your input! I am happy about further input.

Close #348