### PR TITLE
fix(localdevelopment): fix dockerfile.dev to run project locally 

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,6 @@
 FROM jguyomard/hugo-builder:latest
-FROM node:latest
+FROM node:13-alpine
+RUN apk update && apk add python2 make gcc g++
 WORKDIR /src/
 COPY --from=0 /usr/local/bin/hugo /usr/local/bin/hugo
 COPY ./ /src/

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,5 @@
 all: compile-assets compile-site
-all-dev: rebuild-node-sass compile-assets-dev serve-site-dev
-
-compile-site:
-	echo "Generating static website"
-	hugo
-	echo "Website generated"
-
-serve-site-dev:
-	echo "Serving website"
-	hugo serve --bind=0.0.0.0
+all-dev: compile-assets-dev rebuild-node-sass serve-site-dev
 
 compile-assets:
 	echo "Compiling assets"
@@ -19,8 +10,16 @@ compile-assets-dev:
 	echo "Compiling assets"
 	cd themes/conventional-commits && npm install && npm run start &
 
+compile-site:
+	echo "Generating static website"
+	hugo
+	echo "Website generated"
+
 rebuild-node-sass:
 	echo "Rebuilding node sass"
 	cd themes/conventional-commits && npm rebuild node-sass
 	echo "node sass rebuilt"
 
+serve-site-dev:
+	echo "Serving website"
+	hugo serve --bind=0.0.0.0


### PR DESCRIPTION
Cannot run project locally now. because those error happen.

- `gyp verb check python checking for Python executable "python2" in the PATH`
- syntax error by no supported node version

So I add those to dockerfile.dev and I can run project locally.
- specify node version 13 because node 13 supported node-sass version 4.13+, <5.0
- add dependencies because node-sass need python2 and make, g++

