### PR TITLE
docs(readme): 📝 update metadata badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ConventionalCommits.org
 
-[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
 
 This repo is the home of the Conventional Commits specification.
 
@@ -38,7 +38,7 @@ Once the website will be compiled, you can see the website visiting `http://loca
 Tell your users that you use the Conventional Commits specification:
 
 ```markdown
-[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
 ```
 
 ## Thank you


### PR DESCRIPTION
## 📸 Commits

```
docs(readme): 📝 update metadata badge

Update the metadata badge to use the new conventional commits icon in https://simpleicons.org/?q=conventional%20commits.

Closes: #437
```

## 📝 Other Notes

Issue #437 description:

> ## 🏷️ Description
> 
> I created and published a conventional commits icon in the [official simpleicons.org repository](https://simpleicons.org/?q=conventional%20commits):
> 
> ![Conventional Commits SVG in simpleicons.org](https://user-images.githubusercontent.com/16791848/160967025-20149745-388c-43fd-930c-c1df4078f8c4.png)
> 
> You can see the:
> 
> * [`simple-icons` GitHub issue](https://github.com/simple-icons/simple-icons/issues/7027)
> * [`simple-icons` GitHub pull request](https://github.com/simple-icons/simple-icons/pull/7200)
> 
> ## 👀 Example
> 
> This markdown:
> 
> ```markdown
> [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
> ```
> 
> renders the following badge:
> 
> [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
> 
> ## 📝 Other Notes
> 
> * I used the color `#FE5196` because that is defined as the primary theme color in [_variables.scss](https://github.com/conventional-commits/conventionalcommits.org/blob/master/themes/conventional-commits/static/css/scss/abstracts/_variables.scss#L1)
> * Other examples of the badge [can be viewed in the `simple-icons` pull request](https://github.com/simple-icons/simple-icons/pull/7200):
> ![Badge previews](https://user-images.githubusercontent.com/16791848/156997500-de88e103-7bd7-42f3-8bb0-5a531aed9cac.png)
> * I am a big supporter of conventional commits - I even recently got other enterprise teams at work to start using it 🙂