### PR TITLE
fix(pt-br): replace bad example for breaking changes in pt-BR version

### DIFF
--- a/content/v1.0.0/index.pt-br.md
+++ b/content/v1.0.0/index.pt-br.md
@@ -52,18 +52,18 @@ BREAKING CHANGE: a chave `extends`, no arquivo de configuração, agora é utili
 ### Mensagem de commit com `!` para chamar a atenção para quebra a compatibilidade
 
 ```
-refactor!: remove suporte para Node 6
+feat!: envia email para o cliente quando o produto é enviado
 ```
 
 ### Mensagem de commit com escopo e `!` para chamar a atenção para quebra a compatibilidade
 ```
-refactor(execução)!: remove suporte para Node 6
+feat(api)!: envia email para o cliente quando o produto é enviado
 ```
 
 ### Commit message with both `!` and BREAKING CHANGE footer
 
 ```
-refactor!: remove suporte para Node 6
+chore!: remove suporte para Node 6
 
 BREAKING CHANGE: refatorar para usar recursos do JavaScript não disponíveis no Node 6.
 ```


### PR DESCRIPTION
There were some examples including <refactor> type in a breaking
change commit. They were replaced by examples from the english
version.

Refs: #457.