### PR TITLE
fix(theme): remove translations length from dropdown menu

### DIFF
--- a/themes/conventional-commits/layouts/partials/header.html
+++ b/themes/conventional-commits/layouts/partials/header.html
@@ -15,7 +15,6 @@
       <li class="header__menu-item dropdown">
         <button class="dropdown__label">Languages</button>
         <ul class="dropdown__options">
-          {{ .Site.Home.AllTranslations }}
           {{ range .Site.Home.AllTranslations }}
           <li class="dropdown__option"><a href="{{ .Permalink }}">{{ .Language.LanguageName }}</a></li>
           {{ end }}


### PR DESCRIPTION
Removed the translations length printed before the first dropdown option

BUG
<img width="163" alt="bug" src="https://user-images.githubusercontent.com/7217805/198381243-6dd3d15e-bd3a-4844-9836-85f9320602d3.png">

FIX
<img width="159" alt="fix" src="https://user-images.githubusercontent.com/7217805/198381246-230e8031-4447-4a25-bf7d-676d38946489.png">
