### PR TITLE
docs(about): add Homebrew to projects list

### DIFF
--- a/content/about/index.md
+++ b/content/about/index.md
@@ -61,6 +61,7 @@ The first draft of this specification has been written in collaboration with som
 
 ## Projects Using Conventional Commits
 
+* [Homebrew](https://github.com/Homebrew/brew/pulls): The missing package manager for macOS (or Linux).
 * [NFPM](https://github.com/goreleaser/nfpm): NFPM is Not FPM - a simple deb, rpm and apk packager written in Go.
 * [yargs](https://github.com/yargs/yargs): everyone's favorite pirate themed command line argument parser.
 * [istanbuljs](https://github.com/istanbuljs/istanbuljs): a collection of open-source tools and libraries for adding test coverage to your JavaScript tests.


### PR DESCRIPTION
[These](https://github.com/Homebrew/brew/pulls) PRs show that skift uses conventional commits.