### PR TITLE
Fix/de and es translation (#1)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -126,13 +126,16 @@ languages:
     title: Commits Convencionales
     description: Especificación para dar significado a los mensajes de los commits haciéndolos legibles para máquinas y humanos
     actions:
+    - label: Resumen
+      url: '#resumen'
     - label: Lee la especificación
       url: '#especificación'
     - label: GitHub
       url: 'https://github.com/conventional-commits/conventionalcommits.org'
     versions:
-      current: v1.0.0-beta.3
+      current: v1.0.0
       list:
+      - v1.0.0
       - v1.0.0-beta.3
       - v1.0.0-beta.2
 
@@ -267,13 +270,13 @@ languages:
     weight: 14
     languageName: "Deutsch"
     title: Konventionelle Commits
-    description: Eine Spezifikation für menschlich und maschinell lesbare Commit-Nachrichten
+    description: Eine Spezifikation für maschinell und menschenlesbare Commit-Nachrichten
     actions:
     - label: Zusammenfassung
       url: '#zusammenfassung'
     - label: Spezifikation
       url: '#spezifikation'
-    - label: Contribute
+    - label: Mitwirken
       url: 'https://github.com/conventional-commits/conventionalcommits.org'
     versions:
       current: v1.0.0

--- a/content/v1.0.0/index.de.md
+++ b/content/v1.0.0/index.de.md
@@ -7,9 +7,9 @@ aliases: ["/de/"]
 
 ## Zusammenfassung
 
-Die Spezifikation für konventionelle Commits ist eine einfache Konvention, die auf Commit-Nachrichten aufbaut.
+Die Spezifikation für Konventionelle Commits ist eine bloße Konvention, die auf Commit-Nachrichten aufbaut.
 Sie enthält einfache Regeln zum Erstellen einer expliziten Commit-Historie;
-das macht es einfacher, automatisierte Tools dazu zu schreiben.
+das macht es einfacher, automatisierte Tools dafür zu schreiben.
 Diese Konvention knüpft an [SemVer](http://semver.org/lang/de/) an,
 indem sie die Funktionen, Korrekturen und Änderungen beschreibt, die in Commit-Nachrichten vorgenommen wurden.
 
@@ -29,38 +29,38 @@ Die Commit-Nachricht sollte wie folgt aufgebaut sein:
 <br />
 Der Commit enthält die folgenden Strukturelemente, um den Benutzern Ihrer Bibliothek Ihre Absichten mitzuteilen:
 
-1. **fix:** ein Commit des _Typs_ `fix` behebt einen Fehler in Ihrer Codebasis (dies entsprich einem [`PATCH`](http://semver.org/#summary) in semantischer Versionierung).
+1. **fix:** ein Commit des _Typs_ `fix` behebt einen Fehler in Ihrer Codebasis (dies entspricht einem [`PATCH`](http://semver.org/#summary) in semantischer Versionierung).
 1. **feat:** ein Commit des _Typs_ `feat` führt eine neue Funktion in Ihrer Codebasis ein (dies entspricht einem [`MINOR`](http://semver.org/#summary) in semantischer Versionierung).
 1. **BREAKING CHANGE:** ein Commit mit `BREAKING CHANGE:` in der Fußzeile, oder einem angehängten `!` nach dem Typ/Gültigkeitsbereich, führt tiefgreifende Änderungen an der API ein (dies entspricht einem [`MAJOR`](http://semver.org/#summary) in semantischer Versionierung).
-Ein BREAKING CHANGE kann Teil eines Commits jeden _Typs_ sein.
+Ein `BREAKING CHANGE` kann Teil eines Commits jeden _Typs_ sein.
 1. Andere _Typen_ als `fix:` und `feat:` sind erlaubt, z. B. erlaubt [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) (basierend auf [the Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)) `build:`, `chore:`,
-  `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, und andere.
+  `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` und weitere.
 1. Andere _Fußzeilen_ als `BREAKING CHANGE: <Beschreibung>` können angegeben werden und folgen der Konvention ähnlich zum [git Trailer Format](https://git-scm.com/docs/git-interpret-trailers).
 
-Zusätzliche Typen sind in der konventionellen Commit-Spezifikation nicht vorgeschrieben und haben keine impliziten Auswirkungen auf die semantische Versionierung (sofern sie keinen BREAKING CHANGE enthalten).
+Zusätzliche Typen sind in der Konventionellen Commit-Spezifikation nicht vorgeschrieben und haben keine impliziten Auswirkungen auf die semantische Versionierung (sofern sie keinen `BREAKING CHANGE` enthalten).
 <br /><br />
-Ein Gültigkeitsbereich kann zusammen mit einem Commit Typen angegeben werden, um weitere kontextuelle Informationen in Klammern zu geben, z. B. `feat(parser): add ability to parse arrays`.
+Ein Gültigkeitsbereich kann zusammen mit einem Commit-Typen angegeben werden, um weitere kontextuelle Informationen in Klammern zu liefern, z. B. `feat(parser): add ability to parse arrays`.
 
 ## Beispiele
 
-### Commit-Nachricht mit Beschreibung und Breaking Change Fußzeile
+### Commit-Nachricht mit Beschreibung und Fußzeile mit inkompatibler Änderung
 ```
 feat: allow provided config object to extend other configs
 
 BREAKING CHANGE: `extends` key in config file is now used for extending other config files
 ```
 
-### Commit-Nachricht mit `!` um auf einen Breaking Change aufmerksam zu machen
+### Commit-Nachricht mit `!` um auf eine inkompatible Änderung aufmerksam zu machen
 ```
 feat!: send an email to the customer when a product is shipped
 ```
 
-### Commit-Nachricht mit Gültigkeitsbereich und `!` um auf einen Breaking Change aufmerksam zu machen
+### Commit-Nachricht mit Gültigkeitsbereich und `!` um auf eine inkompatible Änderung aufmerksam zu machen
 ```
 feat(api)!: send an email to the customer when a product is shipped
 ```
 
-### Commit-Nachricht mit `!` als auch BREAKING CHANGE Fußzeile
+### Commit-Nachricht mit sowohl `!` als auch `BREAKING CHANGE` Fußzeile
 ```
 chore!: drop support for Node 6
 
@@ -100,23 +100,23 @@ Die Schlüsselwörter "MUSS", "DARF NICHT", "ERFORDERLICH", "SOLL", "SOLL NICHT"
 1. Der Typ `fix` MUSS benutzt werden, wenn ein Commit eine Fehlerbehebung für die Applikation darstellt.
 1. Ein Gültigkeitsbereich KANN nach einem Typen angegeben werden. Ein Gültigkeitsbereich MUSS aus einem Nomen in Klammern bestehen, das die betroffene Stelle im Code beschreibt, z. B. `fix(parser):`
 1. Eine Beschreibung MUSS direkt auf den Doppelpunkt und ein Leerzeichen nach dem Typ/Gültigkeitsbereich folgen. Die Beschreibung ist eine kurze Zusammenfassung der Code-Änderungen, z. B. _fix: array parsing issue when multiple spaces were contained in string_.
-1. Ein längerer Commit-Textkörper KANN nach der Kurzbeschreibung angegeben werden, um weitere kontextuelle Informationen über die Code-Änderungen zu geben. Der Textkörper MUSS nach eine Leerzeile nach der Beschreibung folgen.
+1. Ein längerer Commit-Textkörper KANN nach der Kurzbeschreibung angegeben werden, um weitere kontextuelle Informationen über die Code-Änderungen mitzugeben. Der Textkörper MUSS nach eine Leerzeile nach der Beschreibung folgen.
 1. Der Commit-Textkörper ist formlos und KANN aus einer beliebigen Anzahl an Absätzen bestehen, getrennt mit Zeilenumbrüchen.
 1. Eine oder mehrere Fußzeilen KÖNNEN nach einer Leerzeile unter dem Textkörper angegeben werden. Jede Fußzeile MUSS aus einem Symbolwort bestehen, gefolgt von einem `:<leer>` oder `<leer>#` Trennzeichen und einem String-Wert (basierend auf der [git trailer convention](https://git-scm.com/docs/git-interpret-trailers)).
 1. Symbolwörter MÜSSEN ein `-` statt eines Leerzeichens verwenden, z. B. `Acked-by` (dies hilft die Fußzeile von einem mehrzeiligen Textkörper zu unterscheiden). Eine Ausnahme bildet `BREAKING CHANGE`, was auch als Symbolwort benutzt werden KANN.
 1. Der Wert einer Fußzeile KANN Leerzeichen und Zeilenumbrüche enthalten. Das Parsen MUSS beendet werden, wenn das nächste gültige Paar Fußzeilen-Symbolwort/Trennzeichen erkannt wird.
-1. Breaking Changes MÜSSEN mit dem Typen-/Gültigkeitsbereichs-Präfix eines Commits angegeben werden oder als Eintrag in der Fußzeile.
-1. Wenn ein Breaking Change als Fußzeile eingefügt wird, MUSS sie aus dem Großbuchstaben BREAKING CHANGE bestehen, gefolgt von einem Doppelpunkt, einem Leerzeichen und einer Beschreibung, z. B. _BREAKING CHANGE: environment variables now take precedence over config files_.
-1. Wenn im Typen-/Gültigkeitsbereichs-Präfix enthalten, MÜSSEN Breaking Changes mit einem `!` direkt vor dem `:` angegeben werden. Wenn `!` benutzt wird KANN `BREAKING CHANGE:` aus der Fußzeile weggelassen werden und die Commit-Beschreibung SOLL benutzt werden um den Breaking Change zu beschreiben.
+1. Inkompatible Änderungen (breaking changes) MÜSSEN mit dem Typen-/Gültigkeitsbereichs-Präfix eines Commits angegeben werden oder als Eintrag in der Fußzeile.
+1. Wenn eine inkompatible Änderung als Fußzeile eingefügt wird, MUSS sie aus den Großbuchstaben BREAKING CHANGE bestehen, gefolgt von einem Doppelpunkt, einem Leerzeichen und einer Beschreibung, z. B. _BREAKING CHANGE: environment variables now take precedence over config files_.
+1. Wenn im Typen-/Gültigkeitsbereichs-Präfix enthalten, MÜSSEN inkompatible Änderungen mit einem `!` direkt vor dem `:` angegeben werden. Wenn `!` benutzt wird KANN `BREAKING CHANGE:` aus der Fußzeile weggelassen werden und die Commit-Beschreibung SOLL benutzt werden um die inkompatible Änderung zu beschreiben.
 1. Andere Typen als `feat` und `fix` KÖNNEN in der Commit-Nachricht benutzt werden, z. B. _docs: updated ref docs._
-1. Die Informationseinheiten, aus denen herkömmliche Commits bestehen, DÜRFEN von Implementierern NICHT mit Groß- und Kleinschreibung behandelt werden, mit Ausnahme von BREAKING CHANGE, bei dem es sich um Großbuchstaben handeln MUSS.
+1. Die Informationseinheiten, aus denen herkömmliche Commits bestehen, DÜRFEN von Implementierern NICHT an Groß- und Kleinschreibung gebunden werden, mit Ausnahme von `BREAKING CHANGE`, bei dem es sich um Großbuchstaben handeln MUSS.
 1. BREAKING-CHANGE MUSS mit BREAKING CHANGE synonym bleiben, wenn es als Symbolwort in der Fußzeile benutzt wird.
 
-## Warum konventionelle Commits?
+## Warum Konventionelle Commits?
 
-* Automatisch generierende CHANGELOGs.
+* Automatisch generierte CHANGELOGs.
 * Automatisches Ermitteln einer semantischen Versionserhöhung (basierend auf den eingestellten Commit-Typen).
-* Kommunikation der Art von Änderungen an Teamkollegen, die Öffentlichkeit und andere Stakeholder.
+* Kommunikation der Art von Änderungen an Teamkollegen, die Öffentlichkeit und andere Interessensgruppen.
 * Auslösen von Build- und Veröffentlichungsprozessen.
 * Erleichtern Sie es Leuten, einen Beitrag zu Ihren Projekten zu leisten, indem Sie ihnen ermöglichen, einen strukturierteren Commit-Verlauf zu erkunden.
 
@@ -132,21 +132,21 @@ Das ist ganz Ihnen überlassen, aber seien Sie dabei konsequent.
 
 ### Was mache ich, wenn der Commit mehr als einem der Commit-Typen entspricht?
 
-Gehen Sie zurück und führen Sie nach Möglichkeit mehrere Commits durch. Ein Vorteil von konventionellen Commits ist, dass wir besser organisierte Commits und Pull Requests durchführen können.
+Gehen Sie zurück und führen Sie nach Möglichkeit mehrere Commits durch. Ein Vorteil von Konventionellen Commits ist, dass wir besser organisierte Commits und Pull Requests durchführen können.
 
 ### Verhindert dies nicht eine rasche Entwicklung und schnelle Iteration?
 
-Es verhindert sich auf unorganisierte Weise schnell voranzubewegen. Es hilft Ihnen dabei, sich langfristig und schnell über mehrere Projekte mit unterschiedlichen Mitwirkenden hinweg zu bewegen.
+Es verhindert, sich auf unorganisierte Weise schnell voranzubewegen. Es hilft Ihnen dabei, langfristig und schnell über mehrere Projekte hinweg mit unterschiedlichen Mitwirkenden zu entwickeln.
 
-### Könnten konventionelle Commits Entwickler dazu veranlassen, die Art der Commits zu begrenzen, die sie machen, weil sie in den zur Verfügung gestellten Typen denken werden?
+### Könnten Konventionelle Commits Entwickler dazu veranlassen, die Art der Commits zu begrenzen, die sie machen, weil sie in den zur Verfügung gestellten Typen denken werden?
 
-Konventionelle Commits ermutigen uns, bestimmte Arten von Commits wie z. B. Fixes zu verwenden. Abgesehen davon ermöglicht die Flexibilität der konventionellen Commits Ihrem Team, eigene Typen zu entwickeln und diese Typen im Laufe der Zeit zu ändern.
+Konventionelle Commits ermutigen uns, bestimmte Arten von Commits wie z. B. Fixes zu verwenden. Abgesehen davon ermöglicht die Flexibilität der Konventionellen Commits Ihrem Team, eigene Typen zu entwickeln und diese Typen im Laufe der Zeit zu ändern.
 
 ### In welcher Beziehung steht dies zu SemVer?
 
-Commits vom Typ `fix` sollten wie `PATCH` Releases behandelt werden. Commits vom Typ `feat` sollten wie `MINOR` Releases behandelt werden. Commits mit `BREAKING CHANGE` in den Commits sollten unabhängig vom Typ wie `MAJOR` Releases behandelt werden.
+Commits vom Typ `fix` sollten wie `PATCH` Veröffentlichungen behandelt werden. Commits vom Typ `feat` sollten wie `MINOR` Veröffentlichungen behandelt werden. Commits mit `BREAKING CHANGE` in den Commits sollten unabhängig vom Typ wie `MAJOR` Veröffentlichungen behandelt werden.
 
-### Wie soll ich meine Erweiterungen der konventionellen Commit Spezifikation versionieren, z. B. `@jameswomack/conventional-commit-spec`?
+### Wie soll ich meine Erweiterungen der Konventionellen Commit-Spezifikation versionieren, z. B. `@jameswomack/conventional-commit-spec`?
 
 Wir empfehlen die Verwendung von SemVer, um Ihre eigenen Erweiterungen für diese Spezifikation zu veröffentlichen (und begrüßen es, diese Erweiterungen vorzunehmen!)
 
@@ -154,22 +154,22 @@ Wir empfehlen die Verwendung von SemVer, um Ihre eigenen Erweiterungen für dies
 
 #### Wenn Sie einen Typ verwendet haben, der der Spezifikation, aber nicht dem richtigen Typ entspricht, z. B. `fix` statt `feat`
 
-Vor dem Mergen oder Freigeben des Fehlers wird empfohlen, mit `git rebase -i` die Commit Historie zu bearbeiten. Nach der Veröffentlichung ist die Bereinigung je nach den verwendeten Tools und Prozessen unterschiedlich.
+Vor dem Zusammenführen (merge) oder Freigeben des Fehlers wird empfohlen, mit `git rebase -i` die Commit-Historie zu bearbeiten. Nach der Veröffentlichung ist die Bereinigung je nach den verwendeten Tools und Prozessen unterschiedlich.
 
 #### Wenn Sie einen Typ verwendet haben, der *nicht* der Spezifikation entspricht, z. B. `feet` statt `feat`
 
-Im schlimmsten Fall ist es nicht das Ende der Welt, wenn ein Commit nicht der konventionellen Commit Spezifikation entspricht. Dies bedeutet lediglich, dass der Commit nicht von Tools erfasst wird, die sich an die Spezifikation halten.
+Im schlimmsten Fall ist es nicht das Ende der Welt, wenn ein Commit nicht der Konventionellen Commit-Spezifikation entspricht. Dies bedeutet lediglich, dass der Commit nicht von Tools erfasst wird, die sich an die Spezifikation halten.
 
-### Müssen alle meine Mitwirkenden die konventionelle Commit Spezifikation verwenden?
+### Müssen alle meine Mitwirkenden die Konventionelle Commit-Spezifikation verwenden?
 
-Nein! Wenn Sie einen Squash-basierten Workflow auf Git benutzen, können Lead Maintainer die Commit-Nachrichten beim Mergen bereinigen — ohne gelegentlichen Committern zusätzliche Arbeit aufzubürden.
-Ein üblicher Workflow hierfür ist, dass Ihr Git-System automatisch Commits aus einem Pull Request squasht und dem Lead Maintainer ein Formular vorlegt, in dem er die richtige Git-Commit-Nachricht für den Merge eingibt.
+Nein! Wenn Sie einen Squash-basierten Workflow auf Git benutzen, können Hauptentwickler (lead maintainer) die Commit-Nachrichten beim Zusammenführen (merge) bereinigen — ohne gelegentlich Mitwirkenden zusätzliche Arbeit aufzubürden.
+Ein üblicher Arbeitsablauf hierfür ist, dass Ihr Git-System automatisch Commits aus einem Pull Request komprimiert (squash) und dem Hauptentwickler ein Formular vorlegt, in dem er die richtige Git-Commit-Nachricht für die Zusammenführung (merge) eingibt.
 
 ### Wie geht Conventional Commits mit Revert Commits um?
 
-Das Zurücksetzen von Code kann kompliziert sein: Setzen Sie mehrere Commits zurück? Wenn Sie ein Feature zurücksetzen, sollte die nächste Version stattdessen ein Patch sein?
+Das Zurücksetzen von Code kann kompliziert sein: Setzen Sie mehrere Commits zurück? Wenn Sie ein _Feature_ zurücksetzen, sollte die nächste Version stattdessen ein _Patch_ sein?
 
-Konventionelle Commits bemühen sich nicht explizit, das Wiederherstellungsverhalten zu definieren. Stattdessen überlassen wir es den Autoren, die Flexibilität von _Typen_ und _Fußzeilen_ zu nutzen, um ihre Logik für die Behandlung von Reverts zu entwickeln.
+Konventionelle Commits bemühen sich nicht explizit, das Wiederherstellungsverhalten zu definieren. Stattdessen überlassen wir es den Autoren, die Flexibilität von _Typen_ und _Fußzeilen_ zu nutzen, um ihre Logik für die Behandlung von Rückschritten (rollback) zu entwickeln.
 
 Eine Empfehlung wäre, den `revert` Typ und eine Fußzeile zu verwenden, die auf die zurückgesetzten Commit-SHAs verweist:
 


### PR DESCRIPTION
* Update index.de.md

Fix grammatical errors and add german translation

* Update index.de.md

Adds missing - for consequent usage with English terms

* Update index.de.md

Fixes typos in german translation

* Update index.de.md

Use proper nouns for Conventional Commit consequently in German translation

* Update config.yaml

Translate buttons to german and add spanish internal link to summary

* Update index.de.md

Fix typos and grammatical issues