### PR TITLE
fix(welcome button): align text to vertical center

### DIFF
--- a/themes/conventional-commits/static/css/scss/layout/_welcome.scss
+++ b/themes/conventional-commits/static/css/scss/layout/_welcome.scss
@@ -66,6 +66,7 @@
     padding: 12px 16px;
     border-radius: 50px;
     text-decoration: none;
+    line-height: 1.5;
     color: $welcome-action-color;
     border: 1px solid $welcome-action-color;
     margin-right: $gap-md;


### PR DESCRIPTION
## Description

- Adjusted the welcome button so that the text is aligned to the vertical center, improving visual appearance.

## Motivation

- By merging this Pull Request, the first view of pages in languages such as Chinese and Japanese, which use characters that are displayed larger than alphabets, will appear more aesthetically pleasing. 
- Moreover, it is unlikely to negatively impact the UI of pages in other languages, such as English, making this change beneficial overall.

## Screenshots

- Please refer to the screenshots below for a comparison of the UI differences.

<details>
<summary>UI differences</summary>

| Before | After |
|--------|--------|
| <img width="1912" alt="image" src="https://github.com/conventional-commits/conventionalcommits.org/assets/94698042/5fb02e76-16ae-4c8d-9652-6b8f08425ab1"> | <img width="1912" alt="image" src="https://github.com/conventional-commits/conventionalcommits.org/assets/94698042/b9729fee-f8dc-41b2-9a28-d040abcad3fd"> |
| <img width="1912" alt="image" src="https://github.com/conventional-commits/conventionalcommits.org/assets/94698042/e15a889e-a903-4097-a131-7531e1bb45e0"> | <img width="1912" alt="image" src="https://github.com/conventional-commits/conventionalcommits.org/assets/94698042/007911e6-9e0b-4060-aa49-4d94ec646d8d"> |
| <img width="1912" alt="image" src="https://github.com/conventional-commits/conventionalcommits.org/assets/94698042/d408bfd9-82fc-485a-810e-4a31d8aa1103"> |<img width="1912" alt="image" src="https://github.com/conventional-commits/conventionalcommits.org/assets/94698042/1814a5a5-c09d-4fc9-84be-b74b9dd121ce"> |

</details>