### PR TITLE
docs: add link to website at top of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
 
-This repo is the home of the Conventional Commits specification.
+This repo is the home of the [Conventional Commits specification](https://www.conventionalcommits.org/).
 
 ## Repo Layout
 


### PR DESCRIPTION
Purely to make it easier to find the most readable version of the spec.