### PR TITLE
style: add dark mode theme with toggle functionality

### DIFF
--- a/themes/conventional-commits/layouts/partials/footer.html
+++ b/themes/conventional-commits/layouts/partials/footer.html
@@ -10,7 +10,8 @@
       {{ end }}
     </div>
     <a href="https://www.netlify.com">
-      <img src="https://www.netlify.com/img/global/badges/netlify-light.svg"/>
+      <img class="netlify-badge-light" src="https://www.netlify.com/img/global/badges/netlify-light.svg" alt="Deploys by Netlify"/>
+      <img class="netlify-badge-dark" src="https://www.netlify.com/img/global/badges/netlify-dark.svg" alt="Deploys by Netlify"/>
     </a>
     {{ end }}
     <div class="footer__logos">

--- a/themes/conventional-commits/layouts/partials/head.html
+++ b/themes/conventional-commits/layouts/partials/head.html
@@ -8,8 +8,19 @@
 
     gtag('config', 'UA-2173276-5');
   </script>
-  
+
+  <script>
+    (function() {
+      const theme = localStorage.getItem('theme');
+      if (theme) {
+        document.documentElement.classList.add('theme-' + theme);
+      } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        document.documentElement.classList.add('theme-dark');
+      }
+    })();
+  </script>
   <link rel="stylesheet" href="{{ .Site.BaseURL }}css/style.css">
+  <script src="{{ .Site.BaseURL | absURL }}switchcss.js"></script>
 
   <title>{{ .Param "Title" }}</title>
   <meta name="description" content="{{ .Param "Description" }}"/>

--- a/themes/conventional-commits/layouts/partials/header.html
+++ b/themes/conventional-commits/layouts/partials/header.html
@@ -25,6 +25,9 @@
           <a href="/en/about" class="no-style-a">About</a>
         </button>
       </li>
+      <li class="header__menu-item">
+        {{- partial "theme-toggle.html" . -}}
+      </li>
     </ul>
   </div>
 </header>

--- a/themes/conventional-commits/layouts/partials/theme-toggle.html
+++ b/themes/conventional-commits/layouts/partials/theme-toggle.html
@@ -1,0 +1,7 @@
+<button 
+  class="theme-toggle" 
+  data-theme-toggle 
+  title="Toggle theme"
+  aria-label="Toggle theme">
+  ☀️
+</button>

--- a/themes/conventional-commits/package-lock.json
+++ b/themes/conventional-commits/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hugo-conventional-commits-theme",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hugo-conventional-commits-theme",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "anchor-js": "4.3.1",

--- a/themes/conventional-commits/package.json
+++ b/themes/conventional-commits/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hugo-conventional-commits-theme",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/themes/conventional-commits/static/css/scss/abstracts/_theme-variables.scss
+++ b/themes/conventional-commits/static/css/scss/abstracts/_theme-variables.scss
@@ -1,0 +1,41 @@
+:root {
+  --bg: #ffffff;
+  --surface: #ffffff;
+  --text-primary: #000000;
+  --text-secondary: #666666;
+  --divider: #e1e1e1;
+  --accent-start: #FE5196;
+  --accent-end: #F77062;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0F0C17;
+    --surface: #1E1A29;
+    --text-primary: #E2E2E2;
+    --text-secondary: #A0A0A0;
+    --divider: #3C3748;
+    --accent-start: #6E33D3;
+    --accent-end: #F6705A;
+  }
+}
+
+.theme-dark {
+  --bg: #0F0C17;
+  --surface: #1E1A29;
+  --text-primary: #E2E2E2;
+  --text-secondary: #A0A0A0;
+  --divider: #3C3748;
+  --accent-start: #6E33D3;
+  --accent-end: #F6705A;
+}
+
+.theme-light {
+  --bg: #ffffff;
+  --surface: #ffffff;
+  --text-primary: #000000;
+  --text-secondary: #666666;
+  --divider: #e1e1e1;
+  --accent-start: #FE5196;
+  --accent-end: #F77062;
+}

--- a/themes/conventional-commits/static/css/scss/components/_theme-toggle.scss
+++ b/themes/conventional-commits/static/css/scss/components/_theme-toggle.scss
@@ -1,0 +1,39 @@
+.theme-toggle {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  font-size: 1.2em;
+  cursor: pointer;
+  padding: 8px 12px;
+  border-radius: 6px;
+  transition: all 0.2s ease;
+  color: white;
+  min-width: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  svg {
+    stroke: currentColor;
+    fill: none;
+  }
+
+  &:hover {
+    background-color: rgba(255, 255, 255, 0.2);
+    border-color: rgba(255, 255, 255, 0.4);
+    transform: translateY(-1px);
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+
+  .theme-dark & {
+    background: rgba(255, 255, 255, 0.05);
+    border-color: rgba(255, 255, 255, 0.1);
+
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.1);
+      border-color: rgba(255, 255, 255, 0.2);
+    }
+  }
+}

--- a/themes/conventional-commits/static/css/scss/style.scss
+++ b/themes/conventional-commits/static/css/scss/style.scss
@@ -1,9 +1,12 @@
+@import 'abstracts/theme-variables';
 @import 'base/base';
 @import 'layout/header';
 @import 'layout/footer';
 @import 'layout/welcome';
 @import "components/dropdown";
 @import "components/banner-image";
+@import "components/theme-toggle";
 @import "themes/markdown";
 @import "themes/conventional-commits";
+@import "themes/dark-mode";
 @import "vendors/github-markdown-css";

--- a/themes/conventional-commits/static/css/scss/themes/_dark-mode.scss
+++ b/themes/conventional-commits/static/css/scss/themes/_dark-mode.scss
@@ -185,6 +185,11 @@ html.theme-dark .markdown-body {
   fill: var(--text-secondary);
 }
 
+// Fix hardcoded white text colors
+.theme-dark .no-style-a {
+  color: var(--text-primary) !important;
+}
+
 // Netlify badge theme switching
 .netlify-badge-dark {
   display: none;

--- a/themes/conventional-commits/static/css/scss/themes/_dark-mode.scss
+++ b/themes/conventional-commits/static/css/scss/themes/_dark-mode.scss
@@ -1,0 +1,199 @@
+// Only apply dark theme styles when explicitly in dark mode
+.theme-dark {
+  body {
+    background-color: var(--bg);
+    color: var(--text-primary);
+  }
+
+  main {
+    background-color: var(--bg);
+  }
+
+  article {
+    background-color: var(--surface);
+    color: var(--text-primary);
+  }
+
+  .header {
+    .logo {
+      border-color: var(--text-primary);
+    }
+
+    &__menu {
+      color: var(--text-primary);
+    }
+  }
+
+  .welcome {
+    background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
+
+    .container, .mini_container {
+      color: var(--text-primary);
+    }
+
+    .welcome__action {
+      color: var(--text-primary);
+      border-color: var(--text-primary);
+
+      &:hover {
+        background-color: var(--text-primary);
+        color: var(--bg);
+      }
+    }
+  }
+
+  .dropdown {
+    &__label {
+      color: var(--text-primary);
+    }
+
+    &__options {
+      background-color: var(--surface);
+      border: 1px solid var(--divider);
+
+      // Dark mode scrollbar
+      &::-webkit-scrollbar {
+        width: 8px;
+      }
+
+      &::-webkit-scrollbar-track {
+        background: var(--surface);
+      }
+
+      &::-webkit-scrollbar-thumb {
+        background: var(--divider);
+        border-radius: 4px;
+      }
+
+      &::-webkit-scrollbar-thumb:hover {
+        background: var(--text-secondary);
+      }
+
+      // Arrow pointer color
+      &:before {
+        border-bottom-color: var(--surface) !important;
+      }
+    }
+
+    &__option {
+      border-bottom-color: var(--divider) !important;
+
+      a {
+        color: var(--text-primary);
+        border-bottom: 1px solid var(--divider) !important;
+      }
+
+      &:last-child a {
+        border-bottom: none !important;
+      }
+
+      &:hover {
+        background-color: var(--divider);
+      }
+    }
+  }
+
+  .footer {
+    background-color: var(--surface);
+    color: var(--text-secondary);
+    border-top: 1px solid var(--divider);
+  }
+}
+
+// Override GitHub markdown CSS with higher specificity for dark mode
+.theme-dark .markdown-body,
+html.theme-dark .markdown-body {
+  color: var(--text-primary) !important;
+
+  h1, h2, h3, h4, h5, h6 {
+    color: var(--text-primary) !important;
+    border-bottom-color: var(--divider) !important;
+  }
+
+  p, li {
+    color: var(--text-secondary) !important;
+  }
+
+  blockquote {
+    border-left-color: var(--divider) !important;
+    color: var(--text-secondary) !important;
+  }
+
+  hr {
+    background-color: var(--divider) !important;
+    border-bottom-color: var(--divider) !important;
+  }
+
+  table {
+    border-color: var(--divider) !important;
+
+    th, td {
+      border-color: var(--divider) !important;
+    }
+
+    tr {
+      background-color: var(--surface) !important;
+      border-top-color: var(--divider) !important;
+
+      &:nth-child(2n) {
+        background-color: var(--bg) !important;
+      }
+    }
+  }
+
+  code {
+    background-color: var(--divider) !important;
+    color: var(--text-primary) !important;
+  }
+
+  pre {
+    background-color: var(--surface) !important;
+    border: 1px solid var(--divider) !important;
+
+    code {
+      background-color: transparent !important;
+      color: var(--text-primary) !important;
+    }
+  }
+
+  .highlight pre {
+    background-color: var(--surface) !important;
+  }
+
+  kbd {
+    background-color: var(--surface) !important;
+    border-color: var(--divider) !important;
+    color: var(--text-primary) !important;
+    box-shadow: inset 0 -1px 0 var(--divider) !important;
+  }
+
+  a {
+    color: var(--accent-start) !important;
+
+    &:hover {
+      color: var(--accent-end) !important;
+    }
+  }
+
+  img {
+    background-color: var(--surface) !important;
+  }
+}
+
+// GitHub SVG icon theme switching
+.theme-dark .github path {
+  fill: var(--text-secondary);
+}
+
+// Netlify badge theme switching
+.netlify-badge-dark {
+  display: none;
+}
+
+.theme-dark .netlify-badge-light {
+  display: none;
+}
+
+.theme-dark .netlify-badge-dark {
+  display: inline;
+}

--- a/themes/conventional-commits/static/js/index.js
+++ b/themes/conventional-commits/static/js/index.js
@@ -1,8 +1,10 @@
 import AnchorJS from 'anchor-js';
+import ThemeToggle from './theme-toggle.js';
 
 class App {
   constructor(anchors) {
     this.anchors = anchors;
+    new ThemeToggle();
     this.onInit();
   }
 

--- a/themes/conventional-commits/static/js/theme-toggle.js
+++ b/themes/conventional-commits/static/js/theme-toggle.js
@@ -1,0 +1,90 @@
+class ThemeToggle {
+  constructor() {
+    this.init();
+  }
+
+  init() {
+    this.applyStoredTheme();
+    this.addEventListeners();
+  }
+
+  getStoredTheme() {
+    return localStorage.getItem('theme');
+  }
+
+  setStoredTheme(theme) {
+    localStorage.setItem('theme', theme);
+  }
+
+  getSystemTheme() {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+
+  applyTheme(theme) {
+    const html = document.documentElement;
+    html.classList.remove('theme-light', 'theme-dark');
+
+    if (theme) {
+      html.classList.add(`theme-${theme}`);
+    } else {
+      // No stored preference, use system preference
+      const systemTheme = this.getSystemTheme();
+      if (systemTheme === 'dark') {
+        html.classList.add('theme-dark');
+      }
+    }
+  }
+
+  applyStoredTheme() {
+    const storedTheme = this.getStoredTheme();
+    this.applyTheme(storedTheme);
+  }
+
+  toggle() {
+    const storedTheme = this.getStoredTheme();
+    const effectiveTheme = storedTheme || this.getSystemTheme();
+    const newTheme = effectiveTheme === 'dark' ? 'light' : 'dark';
+
+    this.setStoredTheme(newTheme);
+    this.applyTheme(newTheme);
+    this.updateToggleButton();
+  }
+
+  updateToggleButton() {
+    const button = document.querySelector('[data-theme-toggle]');
+    if (button) {
+      const theme = this.getStoredTheme();
+      const isCurrentlyDark = theme === 'dark' || (!theme && this.getSystemTheme() === 'dark');
+
+      // SVG icons for better cross-platform consistency
+      const sunIcon = '<svg width="16" height="16" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>';
+      const moonIcon = '<svg width="16" height="16" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+
+      const icon = isCurrentlyDark ? sunIcon : moonIcon;
+      const title = `Switch to ${isCurrentlyDark ? 'light' : 'dark'} mode`;
+
+      button.innerHTML = icon;
+      button.title = title;
+    }
+  }
+
+  addEventListeners() {
+    document.addEventListener('DOMContentLoaded', () => {
+      this.updateToggleButton();
+
+      const button = document.querySelector('[data-theme-toggle]');
+      if (button) {
+        button.addEventListener('click', () => this.toggle());
+      }
+    });
+
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+      if (!this.getStoredTheme()) {
+        this.applyStoredTheme();
+        this.updateToggleButton();
+      }
+    });
+  }
+}
+
+export default ThemeToggle;


### PR DESCRIPTION
This pull request adds full support for light and dark themes to the site, including a user-toggleable theme switcher, persistent theme preference, and dynamic styling across all major components. It introduces new SCSS variables and theme-specific styles, updates markup to support theme switching, and adds the necessary JavaScript logic for toggling and storing the user's theme choice.

**Theme support and switching:**

* Added a `ThemeToggle` button (`theme-toggle.html`) to the site header and implemented its styling and logic, allowing users to switch between light and dark modes and persist their preference in `localStorage`. [[1]](diffhunk://#diff-fd82c9c0e39bee32e7788b210f090ab2339f31b2a1ec6b6fa5e3ef96093ed5c3R28-R30) [[2]](diffhunk://#diff-d9a5f3075981ac85c9e006581b3f2fa1576dc6451fe1e89379b69aab4124621aR1-R7) [[3]](diffhunk://#diff-4c74453e43c0ceda57a18b41406ae25dc1f8a65455f67b34cac43fcb3dbef162R1-R39) [[4]](diffhunk://#diff-0fae4fefa4529e26735562dc8c555ca96f1db003453b0b7ece9f486e7fcc689eR1-R90) [[5]](diffhunk://#diff-b9ccd6733236778a711a2c9d3e276f9b247a498557d578d9f448bd8ff26c4b02R2-R7)
* Injected theme class (`theme-dark` or `theme-light`) into the HTML root element on page load, based on user preference or system settings, and loaded the theme toggle script in the main HTML head.

**SCSS and CSS enhancements:**

* Introduced theme variables in `_theme-variables.scss` and imported them into the main stylesheet, enabling consistent color management for both themes. [[1]](diffhunk://#diff-5bd7b22864548265bfd214950d8a178d178593fd66f4300b6656e2d8ca01533fR1-R41) [[2]](diffhunk://#diff-81c184b5f85afa8813f60e7a8e3e5f7d28be463bbb176a85479fdaf0b9bb2bb5R1-R11)
* Added dark mode-specific styles in `_dark-mode.scss` to ensure all components and markdown content are visually coherent in dark mode, including overrides for third-party markdown CSS and icon color switching.

**Visual improvements for theme-specific assets:**

* Updated the Netlify badge in the footer to show the appropriate badge for the current theme, toggling between light and dark SVGs as needed. [[1]](diffhunk://#diff-09382d1e17027058c100ffd0323011f44a50c07a1331c30ac1ea234ef5b4f5edL13-R14) [[2]](diffhunk://#diff-94b814f70ea0ae8edbd9bacbe773a2c6b8834f328a853614f78e9c2ef2a728b2R1-R199)

**Version bump:**

* Updated `package.json` and `package-lock.json` to version 1.1.0 to reflect the addition of theme support. [[1]](diffhunk://#diff-39d7e3ee73ee6aff6edf8352ca2392acaf7a4cccb18e994b26530e143472e356L3-R3) [[2]](diffhunk://#diff-b36fbd875a1395667306453e0c6373b8c8816c20fef91161482285097a65c991L3-R9)

Closes #607