### PR TITLE
feat: add experiment type

### DIFF
--- a/content/next/index.md
+++ b/content/next/index.md
@@ -35,7 +35,7 @@ consumers of your library:
 A BREAKING CHANGE can be part of commits of any _type_.
 1. **INITIAL STABLE RELEASE:**  a commit that has a footer `INITIAL STABLE RELEASE:`, or appends `!!` after the type/scope, and introduces a new `MAJOR` even on versions `< 1.0.0`, denoting the promotion from a pre-release version `0.y.z` to `1.0.0`.
 1. _types_ other than `fix:` and `feat:` are allowed, for example [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) (based on the [the Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)) recommends `build:`, `chore:`,
-  `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others.
+  `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, `experiment:`, and others.
 1. _footers_ other than `BREAKING CHANGE: <description>` or `INITIAL STABLE RELEASE: <description>` may be provided and follow a convention similar to
   [git trailer format](https://git-scm.com/docs/git-interpret-trailers).
 
@@ -96,6 +96,11 @@ docs: correct spelling of CHANGELOG
 ### Commit message with scope
 ```
 feat(lang): add polish language
+```
+
+### Commit message with experiment type
+```
+experiment: try new caching strategy for API responses
 ```
 
 ### Commit message with multi-paragraph body and multiple footers

--- a/content/v1.0.0/index.md
+++ b/content/v1.0.0/index.md
@@ -35,7 +35,7 @@ consumers of your library:
 1. **BREAKING CHANGE:** a commit that has a footer `BREAKING CHANGE:`, or appends a `!` after the type/scope, introduces a breaking API change (correlating with [`MAJOR`](http://semver.org/#summary) in Semantic Versioning).
 A BREAKING CHANGE can be part of commits of any _type_.
 1. _types_ other than `fix:` and `feat:` are allowed, for example [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) (based on the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)) recommends `build:`, `chore:`,
-  `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others.
+  `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, `experiment:`, and others.
 1. _footers_ other than `BREAKING CHANGE: <description>` may be provided and follow a convention similar to
   [git trailer format](https://git-scm.com/docs/git-interpret-trailers).
 
@@ -77,6 +77,11 @@ docs: correct spelling of CHANGELOG
 ### Commit message with scope
 ```
 feat(lang): add Polish language
+```
+
+### Commit message with experiment type
+```
+experiment: try new caching strategy for API responses
 ```
 
 ### Commit message with multi-paragraph body and multiple footers


### PR DESCRIPTION
## Add `experiment` Commit Type

### Problem
Developers frequently create POCs and experimental features deployed to preview environments (Vercel Preview, Netlify Deploy Previews, etc.) for stakeholder testing. These commits may never be merged to master or released to production, but are currently labeled with `feat:` or `chore:`, which can be misleading.

### Solution
Add `experiment:` as a recommended commit type to clearly distinguish experimental work, POCs, and testing implementations from production-ready features.

### Use Cases
- **POCs**: Experimental features deployed to preview environments for stakeholder evaluation
- **Testing & Analysis**: Commits for testing purposes, performance analysis, or A/B testing
- **Stakeholder Review**: Features deployed to preview environments where stakeholders can test before production decisions

### Benefits
- Clear intent: immediately identifies experimental vs production-ready work
- Better tooling: enables automated tools to filter/handle experimental commits differently
- Improved workflow: helps teams distinguish experimental work in commit history
- Semantic clarity: "experiment" clearly stands out from other types

### Example

`experiment: try new caching strategy for API responses`

`experiment(ui): test new dashboard layout for stakeholder review`

### Notes
This is my first contribution to this repository. Happy to make any adjustments as needed!