### PR TITLE
fix: update usage of chore to feat for a breaking change

### DIFF
--- a/content/next/index.md
+++ b/content/next/index.md
@@ -64,7 +64,7 @@ feat(api)!: send an email to the customer when a product is shipped
 
 ### Commit message with both `!` and BREAKING CHANGE footer
 ```
-chore!: drop support for Node 6
+feat!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```

--- a/content/v1.0.0/index.ar.md
+++ b/content/v1.0.0/index.ar.md
@@ -60,7 +60,7 @@ feat(api)!: send an email to the customer when a product is shipped
 
 ### رسالة التزام تحتوي على `!` و footer لتغيير جذري
 ```
-chore!: drop support for Node 6
+feat!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```

--- a/content/v1.0.0/index.be.md
+++ b/content/v1.0.0/index.be.md
@@ -75,7 +75,7 @@ feat(api)!: send an email to the customer when a product is shipped
 
 ### Паведамленне каміту разам з `!` і _зноскай_ `BREAKING CHANGE`
 ```
-chore!: drop support for Node 6
+feat!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```

--- a/content/v1.0.0/index.bn.md
+++ b/content/v1.0.0/index.bn.md
@@ -69,7 +69,7 @@ feat(api)!: send an email to the customer when a product is shipped
  
 ### পরিশেষে (footer) উল্লেখযোগ্য পরিবর্তন (BREAKING CHANGE) এবং `!` , উভয় সহ কমিট বার্তা 
 ```
-chore!: drop support for Node 6
+feat!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```

--- a/content/v1.0.0/index.de.md
+++ b/content/v1.0.0/index.de.md
@@ -62,7 +62,7 @@ feat(api)!: send an email to the customer when a product is shipped
 
 ### Commit-Nachricht mit `!` als auch BREAKING CHANGE Fußzeile
 ```
-chore!: drop support for Node 6
+feat!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```

--- a/content/v1.0.0/index.fr.md
+++ b/content/v1.0.0/index.fr.md
@@ -70,7 +70,7 @@ feat(api)!: send an email to the customer when a product is shipped
 
 ### Message du commit avec `!` et BREAKING CHANGE dans le _pied_
 ```
-chore!: drop support for Node 6
+feat!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```

--- a/content/v1.0.0/index.hy.md
+++ b/content/v1.0.0/index.hy.md
@@ -61,7 +61,7 @@ feat(api)!: send an email to the customer when a product is shipped
 
 ### Commit հաղորդագրություն՝ միաժամանակ և՛ `!` նշանով, և՛ BREAKING CHANGE վերջավորությունով
 ```
-chore!: drop support for Node 6
+feat!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```

--- a/content/v1.0.0/index.id.md
+++ b/content/v1.0.0/index.id.md
@@ -62,7 +62,7 @@ feat(api)!: send an email to the customer when a product is shipped
 
 ### Pesan komit dengan keduanya `!` dan footer BREAKING CHANGE
 ```
-chore!: drop support for Node 6
+feat!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```

--- a/content/v1.0.0/index.ja.md
+++ b/content/v1.0.0/index.ja.md
@@ -79,7 +79,7 @@ feat(api)!: send an email to the customer when a product is shipped
 ### `!` と BREAKING CHANGE フッターの両方を持つコミットメッセージ
 
 ```
-chore!: drop support for Node 6
+feat!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```

--- a/content/v1.0.0/index.ko.md
+++ b/content/v1.0.0/index.ko.md
@@ -59,7 +59,7 @@ feat(api)!: send an email to the customer when a product is shipped
 
 ### BREAKING CHANGE 꼬리말과 `!`를 함께 포함한 커밋 메시지
 ```
-chore!: drop support for Node 6
+feat!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```

--- a/content/v1.0.0/index.md
+++ b/content/v1.0.0/index.md
@@ -64,7 +64,7 @@ feat(api)!: send an email to the customer when a product is shipped
 
 ### Commit message with both `!` and BREAKING CHANGE footer
 ```
-chore!: drop support for Node 6
+feat!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```

--- a/content/v1.0.0/index.ml.md
+++ b/content/v1.0.0/index.ml.md
@@ -64,7 +64,7 @@ feat(api)!: send an email to the customer when a product is shipped
 
 ### `!` എന്നതും ബ്രേക്കിംഗ് മാറ്റുക അടിക്കുറിപ്പും ഉപയോഗിച്ച് കമ്മിറ്റ് സന്ദേശം
 ```
-chore!: drop support for Node 6
+feat!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```

--- a/content/v1.0.0/index.nl.md
+++ b/content/v1.0.0/index.nl.md
@@ -81,7 +81,7 @@ feat(api)!: send an email to the customer when a product is shipped
 ### Commit-bericht met zowel een `!` als BREAKING CHANGE in de voettekst
 
 ```
-chore!: drop support for Node 6
+feat!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```

--- a/content/v1.0.0/index.pl.md
+++ b/content/v1.0.0/index.pl.md
@@ -66,7 +66,7 @@ feat(api)!: send an email to the customer when a product is shipped
 ### Commit message z `!` i footerm (stopką) BREAKING CHANGE
 
 ```
-chore!: drop support for Node 6
+feat!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```

--- a/content/v1.0.0/index.pr.md
+++ b/content/v1.0.0/index.pr.md
@@ -63,7 +63,7 @@ feat(api)!: send an email to the customer when a product is shipped
 
 ### کامیت همراه `!` و فوتر BREAKING CHANGE بطور همزمان
 ```
-chore!: drop support for Node 6
+feat!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```

--- a/content/v1.0.0/index.pt-br.md
+++ b/content/v1.0.0/index.pt-br.md
@@ -63,7 +63,7 @@ feat(api)!: envia email para o cliente quando o produto é enviado
 ### Mensagem de commit com `!` e BREAKING CHANGE no rodapé
 
 ```
-chore!: remove suporte para Node 6
+feat:! remove suporte para Node 6
 
 BREAKING CHANGE: refatorar para usar recursos do JavaScript não disponíveis no Node 6.
 ```

--- a/content/v1.0.0/index.ro.md
+++ b/content/v1.0.0/index.ro.md
@@ -66,7 +66,7 @@ feat(api)!: send an email to the customer when a product is shipped
 ### Mesaj de comitere și cu `!` și cu subsol de modificări care afectează funcționalitatea
 
 ```
-chore!: drop support for Node 6
+feat!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```

--- a/content/v1.0.0/index.ru.md
+++ b/content/v1.0.0/index.ru.md
@@ -75,7 +75,7 @@ feat(api)!: send an email to the customer when a product is shipped
 
 ### Сообщение коммита вместе с `!` и _сноской_ `BREAKING CHANGE`
 ```
-chore!: drop support for Node 6
+feat!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```

--- a/content/v1.0.0/index.ta.md
+++ b/content/v1.0.0/index.ta.md
@@ -68,7 +68,7 @@ feat(api)!: send an email to the customer when a product is shipped
 
 ### `!` மற்றும் BREAKING CHANGE footer இரண்டையும் கொண்டு கமிட் செய்தியை கமிட் செய்யவும்
 ```
-chore!: drop support for Node 6
+feat!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```

--- a/content/v1.0.0/index.th.md
+++ b/content/v1.0.0/index.th.md
@@ -63,7 +63,7 @@ feat(api)!: send an email to the customer when a product is shipped
 
 ### ข้อความ commit ที่มีทั้ง `!` และ BREAKING CHANGE ลงท้าย
 ```
-chore!: drop support for Node 6
+feat!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```

--- a/content/v1.0.0/index.tr.md
+++ b/content/v1.0.0/index.tr.md
@@ -63,7 +63,7 @@ feat(api)!: müşteriye, ürünü kargolandığında mail atma özelliği eklend
 ### `!` ve köklü değişiklik alt metni içeren commit mesajı
 
 ```
-chore!: Node 6 desteği kaldırıldı
+feat:! Node 6 desteği kaldırıldı
 
 BREAKING CHANGE: Sadece Node 6 içinde olan Javascript özellikleri kullanan yerler yeniden yazılmalı.
 ```

--- a/content/v1.0.0/index.uk.md
+++ b/content/v1.0.0/index.uk.md
@@ -65,7 +65,7 @@ feat(api)!: send an email to the customer when a product is shipped
 
 ### Коміт повідомлення з `!` та BREAKING CHANGE додатком
 ```
-chore!: drop support for Node 6
+feat!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```

--- a/content/v1.0.0/index.uz.md
+++ b/content/v1.0.0/index.uz.md
@@ -60,7 +60,7 @@ feat(api)!: send an email to the customer when a product is shipped
 ### `BREAKING CHANGE` ni ifodalovchi `!` belgi va _footerga_ ega commit xabarlari
 
 ```
-chore!: drop support for Node 6
+feat!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```

--- a/content/v1.0.0/index.zh-hans.md
+++ b/content/v1.0.0/index.zh-hans.md
@@ -83,7 +83,7 @@ feat(api)!: send an email to the customer when a product is shipped
 
 ### 包含了 `!` 和 BREAKING CHANGE 脚注的提交说明
 ```
-chore!: drop support for Node 6
+feat!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```

--- a/content/v1.0.0/index.zh-hant.md
+++ b/content/v1.0.0/index.zh-hant.md
@@ -68,7 +68,7 @@ feat(api)!: send an email to the customer when a product is shipped
 
 ### 包含 `!` 以及頁腳有重大變更的提交說明
 ```
-chore!: drop support for Node 6
+feat!: drop support for Node 6
 
 BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```


### PR DESCRIPTION
Clarifies and updates usage of `chore!` to `feat!:` for the breaking changes examples. `chore` often gets overlooked in changelog generation even with a breaking change.

Examples from Angular repo also: https://github.com/angular/angular/pulls?q=is%3Apr+%22drop+support%22+is%3Aclosed+typescript+