### PR TITLE
docs: add changegen to tooling list

### DIFF
--- a/content/next/index.md
+++ b/content/next/index.md
@@ -268,6 +268,7 @@ Configurable and usable for PHP projects as a composer dependency or usable glob
 * [Cocogitto](https://github.com/oknozor/cocogitto): Cocogitto is a set of cli tools for the conventional commits and semver specifications.
 * [Conventional Commits Linter](https://gitlab.com/DeveloperC/conventional_commits_linter): A tooling and language agnostic Git commit linter for the _Conventional Commits_ specification.
 * [Uplift](https://github.com/gembaadvantage/uplift): Semantic versioning the easy way. Powered by Conventional Commits. Built for use with CI
+* [changegen](https://github.com/creativengine-ai/changegen): A zero-dependency Node.js CLI for generating formatted changelogs from git history using Conventional Commits. Supports multiple output formats and includes a ready-to-use GitHub Action.
 
 ## Projects Using Conventional Commits
 


### PR DESCRIPTION
## What

Adds [changegen](https://github.com/creativengine-ai/changegen) to the tooling section of the specification.

## Why

changegen is a zero-dependency Node.js CLI for generating formatted changelogs from git history using the Conventional Commits specification. It supports:

- Multiple output formats (Markdown, terminal display)
- Scoped ranges via `--from` / `--to` flags
- Ready-to-use GitHub Action for CI/CD

It fills a niche for teams that want a simple, `npx`-ready changelog generator without pulling in a larger toolchain.

## Entry added

```
* [changegen](https://github.com/creativengine-ai/changegen): A zero-dependency Node.js CLI for generating formatted changelogs from git history using Conventional Commits. Supports multiple output formats and includes a ready-to-use GitHub Action.
```