### PR TITLE
fix(uk): correct anchor links in Ukrainian menu

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -321,9 +321,9 @@ languages:
     description: Угода для додавання зручних для читання коміт повідомлень для людей та роботів
     actions:
     - label: Швидкий Огляд
-      url: '#summary'
+      url: '#вступ'
     - label: Повна Специфікація
-      url: '#specification'
+      url: '#специфікація'
     - label: Контрибуція
       url: 'https://github.com/conventional-commits/conventionalcommits.org'
     versions:


### PR DESCRIPTION
The "Швидкий Огляд" and "Повна Специфікація" buttons on https://www.conventionalcommits.org/uk/v1.0.0/ pointed to #summary and #specification, which don't exist on the Ukrainian page.
The actual headings are ## Вступ and ## Специфікація, so the auto-generated anchor IDs are #вступ and #специфікація.
